### PR TITLE
feat: add basic Codex hook provider (presence + turn-end + Bash events)

### DIFF
--- a/esbuild.js
+++ b/esbuild.js
@@ -39,26 +39,23 @@ function copyAssets() {
  * Produces a self-contained CJS file with shebang for Claude Code to execute.
  */
 function buildHooks() {
-  const entry = path.join(
-    __dirname,
-    'server',
-    'src',
-    'providers',
-    'hook',
-    'claude',
-    'hooks',
-    'claude-hook.ts',
-  );
-  if (!fs.existsSync(entry)) return;
-  require('esbuild').buildSync({
-    entryPoints: [entry],
-    bundle: true,
-    platform: 'node',
-    target: 'node18',
-    format: 'cjs',
-    outdir: path.join(__dirname, 'dist', 'hooks'),
-    banner: { js: '#!/usr/bin/env node' },
-  });
+  const entries = [
+    path.join(__dirname, 'server', 'src', 'providers', 'hook', 'claude', 'hooks', 'claude-hook.ts'),
+    path.join(__dirname, 'server', 'src', 'providers', 'hook', 'codex', 'hooks', 'codex-hook.ts'),
+  ].filter((entry) => fs.existsSync(entry));
+  if (entries.length === 0) return;
+  const outDir = path.join(__dirname, 'dist', 'hooks');
+  for (const entry of entries) {
+    require('esbuild').buildSync({
+      entryPoints: [entry],
+      bundle: true,
+      platform: 'node',
+      target: 'node18',
+      format: 'cjs',
+      outfile: path.join(outDir, path.basename(entry).replace(/\.ts$/, '.js')),
+      banner: { js: '#!/usr/bin/env node' },
+    });
+  }
   console.log('✓ Built hooks/ → dist/hooks/');
 }
 

--- a/server/__tests__/codex.test.ts
+++ b/server/__tests__/codex.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+
+import { codexProvider } from '../src/providers/hook/codex/codex.js';
+
+describe('codexProvider', () => {
+  describe('identity', () => {
+    it('has kind "hook"', () => {
+      expect(codexProvider.kind).toBe('hook');
+    });
+    it('has id "codex"', () => {
+      expect(codexProvider.id).toBe('codex');
+    });
+    it('has a displayName', () => {
+      expect(codexProvider.displayName).toBe('Codex');
+    });
+    it('has protocolVersion 1', () => {
+      expect(codexProvider.protocolVersion).toBe(1);
+    });
+    it('has no team, subagent, or reading-tool concept', () => {
+      expect(codexProvider.team).toBeUndefined();
+      expect(codexProvider.subagentToolNames.size).toBe(0);
+      expect(codexProvider.readingTools.size).toBe(0);
+    });
+  });
+
+  describe('normalizeHookEvent', () => {
+    it('returns null when hook_event_name is missing', () => {
+      expect(codexProvider.normalizeHookEvent({ session_id: 'x' })).toBeNull();
+    });
+    it('returns null when session_id is missing', () => {
+      expect(codexProvider.normalizeHookEvent({ hook_event_name: 'Stop' })).toBeNull();
+    });
+    it('returns null for unknown hook event names', () => {
+      expect(
+        codexProvider.normalizeHookEvent({
+          hook_event_name: 'SomethingWeird',
+          session_id: 'x',
+        }),
+      ).toBeNull();
+    });
+    it('returns null for UserPromptSubmit (no normalized kind yet)', () => {
+      expect(
+        codexProvider.normalizeHookEvent({
+          hook_event_name: 'UserPromptSubmit',
+          session_id: 'sess-1',
+        }),
+      ).toBeNull();
+    });
+
+    it('normalizes SessionStart with source + cwd', () => {
+      const result = codexProvider.normalizeHookEvent({
+        hook_event_name: 'SessionStart',
+        session_id: 'sess-1',
+        source: 'startup',
+        cwd: '/home/user/project',
+      });
+      expect(result?.sessionId).toBe('sess-1');
+      expect(result?.event).toEqual({
+        kind: 'sessionStart',
+        source: 'startup',
+        cwd: '/home/user/project',
+      });
+    });
+
+    it('normalizes PreToolUse (Bash-only) into toolStart', () => {
+      const result = codexProvider.normalizeHookEvent({
+        hook_event_name: 'PreToolUse',
+        session_id: 'sess-1',
+        tool_name: 'Bash',
+        tool_input: { command: 'npm test' },
+      });
+      expect(result?.sessionId).toBe('sess-1');
+      expect(result?.event.kind).toBe('toolStart');
+      if (result?.event.kind === 'toolStart') {
+        expect(result.event.toolName).toBe('Bash');
+        expect(result.event.input).toEqual({ command: 'npm test' });
+      }
+    });
+
+    it('normalizes PostToolUse into toolEnd', () => {
+      const result = codexProvider.normalizeHookEvent({
+        hook_event_name: 'PostToolUse',
+        session_id: 'sess-1',
+      });
+      expect(result?.event).toEqual({ kind: 'toolEnd', toolId: 'current' });
+    });
+
+    it('normalizes Stop into turnEnd', () => {
+      const result = codexProvider.normalizeHookEvent({
+        hook_event_name: 'Stop',
+        session_id: 'sess-1',
+      });
+      expect(result?.event).toEqual({ kind: 'turnEnd' });
+    });
+  });
+
+  describe('formatToolStatus', () => {
+    it('formats Bash commands the same way Claude does', () => {
+      expect(codexProvider.formatToolStatus('Bash', { command: 'npm test' })).toBe(
+        'Running: npm test',
+      );
+    });
+  });
+});

--- a/server/src/agentRuntime.ts
+++ b/server/src/agentRuntime.ts
@@ -72,6 +72,9 @@ export class AgentRuntime {
   constructor(
     private readonly store: AgentStateStore,
     provider: HookProvider,
+    /** Additional hook providers (e.g. Codex) whose events normalize alongside
+     *  the primary provider. See HookEventHandler.resolveProvider. */
+    secondaryProviders: HookProvider[] = [],
   ) {
     // Wire module-level dependencies
     setDismissalTracker(this.dismissalTracker);
@@ -90,6 +93,7 @@ export class AgentRuntime {
       provider,
       new SessionRouter(),
       this.watchAllSessions,
+      secondaryProviders,
     );
 
     // Wire hook lifecycle callbacks to shared agent operations

--- a/server/src/cli.ts
+++ b/server/src/cli.ts
@@ -8,6 +8,8 @@
  * Each connecting WebSocket client receives the full state on webviewReady.
  */
 
+import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 
 import { AgentRuntime } from './agentRuntime.js';
@@ -22,8 +24,17 @@ import {
 } from './assetLoader.js';
 import type { AssetCache } from './clientMessageHandler.js';
 import { FileStateAdapter } from './fileStateAdapter.js';
-import { claudeProvider, copyHookScript } from './providers/index.js';
+import {
+  claudeProvider,
+  codexProvider,
+  copyCodexHookScript,
+  copyHookScript,
+} from './providers/index.js';
 import { PixelAgentsServer } from './server.js';
+
+/** Only wire the Codex provider on machines that actually use Codex, so we
+ *  never create a `~/.codex/` directory or config on machines without it. */
+const codexAvailable = fs.existsSync(path.join(os.homedir(), '.codex'));
 
 // ── Argument parsing ──────────────────────────────────────────
 
@@ -90,7 +101,7 @@ async function main(): Promise<void> {
 
   try {
     // Create runtime first (before server.start, so we can pass it in)
-    const runtime = new AgentRuntime(store, claudeProvider);
+    const runtime = new AgentRuntime(store, claudeProvider, codexAvailable ? [codexProvider] : []);
 
     // Wire hook events: HTTP POST -> runtime -> hookEventHandler -> agents
     server.onHookEvent((providerId, event) => {
@@ -108,9 +119,19 @@ async function main(): Promise<void> {
           currentConfig.token,
         );
         copyHookScript(distRoot);
+        if (codexAvailable) {
+          await codexProvider.installHooks(
+            `http://127.0.0.1:${currentConfig.port}`,
+            currentConfig.token,
+          );
+          copyCodexHookScript(distRoot);
+        }
         console.log('[Pixel Agents] Hooks installed (user toggle)');
       } else {
         await claudeProvider.uninstallHooks();
+        if (codexAvailable) {
+          await codexProvider.uninstallHooks();
+        }
         console.log('[Pixel Agents] Hooks uninstalled (user toggle)');
       }
     };
@@ -137,6 +158,11 @@ async function main(): Promise<void> {
         await claudeProvider.installHooks(`http://127.0.0.1:${config.port}`, config.token);
         copyHookScript(distRoot);
         console.log('[Pixel Agents] Hooks installed');
+        if (codexAvailable) {
+          await codexProvider.installHooks(`http://127.0.0.1:${config.port}`, config.token);
+          copyCodexHookScript(distRoot);
+          console.log('[Pixel Agents] Codex hooks installed');
+        }
       } catch (err) {
         console.error('[Pixel Agents] Failed to install hooks:', err);
       }

--- a/server/src/hookEventHandler.ts
+++ b/server/src/hookEventHandler.ts
@@ -68,6 +68,11 @@ export class HookEventHandler {
     private provider: HookProvider,
     private sessionRouter: SessionRouter,
     private watchAllSessionsRef?: { current: boolean },
+    /** Additional providers whose events should also normalize (e.g. Codex
+     *  alongside the primary Claude provider). Only `normalizeHookEvent` is
+     *  consulted per-provider; team/tool-display metadata stays on the primary
+     *  provider since secondary providers here have no team/subagent concept. */
+    private secondaryProviders: HookProvider[] = [],
   ) {
     if (provider.protocolVersion !== HookEventHandler.SUPPORTED_PROTOCOL_VERSION) {
       console.warn(
@@ -76,6 +81,12 @@ export class HookEventHandler {
           `Events from this provider will be dropped.`,
       );
     }
+  }
+
+  /** Resolve which provider's normalizeHookEvent should handle this providerId. */
+  private resolveProvider(providerId: string): HookProvider {
+    if (providerId === this.provider.id) return this.provider;
+    return this.secondaryProviders.find((p) => p.id === providerId) ?? this.provider;
   }
 
   /** Merged set of tool names that spawn subagents (teammates + within-turn subagents
@@ -128,17 +139,18 @@ export class HookEventHandler {
    * @param providerId - Provider that sent the event ('claude', 'codex', etc.)
    * @param event - The hook event payload from the CLI tool
    */
-  handleEvent(_providerId: string, event: HookEvent): void {
-    if (this.provider.protocolVersion !== HookEventHandler.SUPPORTED_PROTOCOL_VERSION) {
+  handleEvent(providerId: string, event: HookEvent): void {
+    const provider = this.resolveProvider(providerId);
+    if (provider.protocolVersion !== HookEventHandler.SUPPORTED_PROTOCOL_VERSION) {
       return; // version mismatch already logged in constructor
     }
     // ── Provider normalization boundary ───────────────────────────────────────
-    // All raw Claude-specific fields (tool_name, tool_input, agent_type, notification_type,
+    // All raw CLI-specific fields (tool_name, tool_input, agent_type, notification_type,
     // reason, source) are extracted by provider.normalizeHookEvent. Downstream dispatch
     // uses the normalized AgentEvent.kind. Raw `event.*` reads are still allowed in a few
     // places for provider-specific metadata that AgentEvent doesn't capture (transcript_path,
     // cwd for external-session adoption; agent_type for teammate routing).
-    const normalized = this.provider.normalizeHookEvent(event);
+    const normalized = provider.normalizeHookEvent(event);
     if (!normalized) return; // unknown / uninteresting event -- silently drop
     const normEvent = normalized.event;
     const eventName = event.hook_event_name; // retained for logs only
@@ -275,7 +287,7 @@ export class HookEventHandler {
         pending.cwd,
       );
       // Re-process this event now that the agent exists
-      this.handleEvent(_providerId, event);
+      this.handleEvent(providerId, event);
       return;
     }
 
@@ -305,7 +317,7 @@ export class HookEventHandler {
           console.log(
             `[Pixel Agents] Hook: ${eventName} - unknown session ${event.session_id.slice(0, 8)}..., buffering`,
           );
-        this.sessionRouter.bufferEvent(_providerId, event);
+        this.sessionRouter.bufferEvent(providerId, event);
       }
       return;
     }

--- a/server/src/providers/hook/codex/codex.ts
+++ b/server/src/providers/hook/codex/codex.ts
@@ -1,0 +1,111 @@
+import type { AgentEvent, HookProvider } from '../../../../../core/src/provider.js';
+import { formatToolStatus as claudeFormatToolStatus } from '../claude/claude.js';
+import {
+  areHooksInstalled as installerAreHooksInstalled,
+  installHooks as installerInstallHooks,
+  uninstallHooks as installerUninstallHooks,
+} from './codexHookInstaller.js';
+import { CODEX_TERMINAL_NAME_PREFIX } from './constants.js';
+
+// ── normalizeHookEvent: the single Codex-specific normalization boundary ──
+//
+// Codex's hooks system is experimental and only fires 5 events (SessionStart,
+// PreToolUse/PostToolUse restricted to Bash, UserPromptSubmit, Stop). The
+// payload shares the `hook_event_name` / `session_id` / `cwd` / `transcript_path`
+// field names Claude Code uses, so this maps to the same normalized AgentEvent
+// union with no new event kinds. There is no subagent, file-write, notification,
+// or session-end coverage on Codex today -- those AgentEvents are simply never
+// emitted for Codex sessions.
+
+function normalizeHookEvent(
+  raw: Record<string, unknown>,
+): { sessionId: string; event: AgentEvent } | null {
+  const eventName = raw.hook_event_name;
+  const sessionId = raw.session_id;
+  if (typeof eventName !== 'string' || typeof sessionId !== 'string') return null;
+
+  switch (eventName) {
+    case 'PreToolUse': {
+      const toolName = typeof raw.tool_name === 'string' ? raw.tool_name : 'Bash';
+      const toolInput =
+        typeof raw.tool_input === 'object' && raw.tool_input !== null
+          ? (raw.tool_input as Record<string, unknown>)
+          : {};
+      return {
+        sessionId,
+        event: {
+          kind: 'toolStart',
+          toolId: `hook-${Date.now()}`,
+          toolName,
+          input: toolInput,
+        },
+      };
+    }
+
+    case 'PostToolUse':
+      return { sessionId, event: { kind: 'toolEnd', toolId: 'current' } };
+
+    case 'Stop':
+      return { sessionId, event: { kind: 'turnEnd' } };
+
+    case 'UserPromptSubmit':
+      // No normalized kind for user prompts yet; silently ignore.
+      return null;
+
+    case 'SessionStart':
+      return {
+        sessionId,
+        event: {
+          kind: 'sessionStart',
+          source: typeof raw.source === 'string' ? raw.source : undefined,
+          cwd: typeof raw.cwd === 'string' ? raw.cwd : undefined,
+        },
+      };
+
+    default:
+      return null;
+  }
+}
+
+// ── Installer wrappers: adapt sync signatures to async interface ──
+
+function installHooks(_serverUrl: string, _authToken: string): Promise<void> {
+  installerInstallHooks();
+  return Promise.resolve();
+}
+
+function uninstallHooks(): Promise<void> {
+  installerUninstallHooks();
+  return Promise.resolve();
+}
+
+function areHooksInstalled(): Promise<boolean> {
+  return Promise.resolve(installerAreHooksInstalled());
+}
+
+// ── The provider ──
+//
+// Codex has no transcript files pixel-agents can poll (no heuristic fallback),
+// no Agent Teams equivalent, and no subagent lifecycle -- so getSessionDirs,
+// buildLaunchCommand, and `team` are all omitted rather than stubbed.
+
+export const codexProvider: HookProvider = {
+  kind: 'hook',
+  id: 'codex',
+  displayName: 'Codex',
+  protocolVersion: 1,
+
+  normalizeHookEvent,
+
+  installHooks,
+  uninstallHooks,
+  areHooksInstalled,
+
+  // Reused verbatim: Codex's only tool event is Bash, and Claude's formatToolStatus
+  // already renders "Running: <command>" for it.
+  formatToolStatus: claudeFormatToolStatus,
+  permissionExemptTools: new Set(),
+  subagentToolNames: new Set(),
+  readingTools: new Set(),
+  terminalNamePrefix: CODEX_TERMINAL_NAME_PREFIX,
+};

--- a/server/src/providers/hook/codex/codexHookInstaller.ts
+++ b/server/src/providers/hook/codex/codexHookInstaller.ts
@@ -1,0 +1,224 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { HOOK_SCRIPTS_DIR } from '../../../constants.js';
+import { CODEX_HOOK_EVENTS, CODEX_HOOK_SCRIPT_NAME } from './constants.js';
+
+/** Marker string used to identify Pixel Agents hook entries in Codex's hooks.json. */
+const HOOK_SCRIPT_MARKER = CODEX_HOOK_SCRIPT_NAME;
+
+/** A single hook entry in Codex's ~/.codex/hooks.json config. Same shape as
+ *  Claude's settings.json hooks -- Codex's hooks system was modeled on it. */
+interface CodexHookEntry {
+  matcher?: string;
+  hooks: Array<{
+    type: string;
+    command: string;
+    timeout?: number;
+  }>;
+}
+
+/** Partial shape of ~/.codex/hooks.json (only the hooks field is relevant). */
+interface CodexHooksFile {
+  hooks?: Record<string, CodexHookEntry[]>;
+  [key: string]: unknown;
+}
+
+function getCodexDir(): string {
+  return path.join(os.homedir(), '.codex');
+}
+
+function getCodexHooksPath(): string {
+  return path.join(getCodexDir(), 'hooks.json');
+}
+
+function getCodexConfigPath(): string {
+  return path.join(getCodexDir(), 'config.toml');
+}
+
+/** Returns the destination path for the hook script (~/.pixel-agents/hooks/codex-hook.js). */
+function getHookScriptPath(): string {
+  return path.join(os.homedir(), HOOK_SCRIPTS_DIR, CODEX_HOOK_SCRIPT_NAME);
+}
+
+function readCodexHooks(): CodexHooksFile {
+  const p = getCodexHooksPath();
+  try {
+    if (fs.existsSync(p)) {
+      return JSON.parse(fs.readFileSync(p, 'utf-8')) as CodexHooksFile;
+    }
+  } catch (e) {
+    console.error(`[Pixel Agents] Failed to read Codex hooks.json: ${e}`);
+  }
+  return {};
+}
+
+function writeCodexHooks(hooksFile: CodexHooksFile): void {
+  const p = getCodexHooksPath();
+  const dir = path.dirname(p);
+  try {
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+    const tmpPath = p + '.pixel-agents-tmp';
+    fs.writeFileSync(tmpPath, JSON.stringify(hooksFile, null, 2), 'utf-8');
+    fs.renameSync(tmpPath, p);
+  } catch (e) {
+    console.error(`[Pixel Agents] Failed to write Codex hooks.json: ${e}`);
+  }
+}
+
+/** Codex's hooks system is behind a feature flag: `[features] codex_hooks = true`
+ *  in config.toml. This does a targeted, single-line edit -- it only recognizes
+ *  a top-level `[features]` table with a plain `codex_hooks = <bool>` line, which
+ *  covers the common case without pulling in a full TOML parser/writer dependency.
+ *  If the file has a more complex `[features]` block this function leaves it
+ *  alone and logs a warning so the user can flip the flag by hand. */
+function ensureCodexHooksFeatureFlag(): void {
+  const configPath = getCodexConfigPath();
+  let text = '';
+  try {
+    if (fs.existsSync(configPath)) {
+      text = fs.readFileSync(configPath, 'utf-8');
+    }
+  } catch (e) {
+    console.error(`[Pixel Agents] Failed to read Codex config.toml: ${e}`);
+    return;
+  }
+
+  if (/^\s*codex_hooks\s*=\s*true\s*$/m.test(text)) return; // already enabled
+
+  if (/^\s*codex_hooks\s*=\s*false\s*$/m.test(text)) {
+    text = text.replace(/^\s*codex_hooks\s*=\s*false\s*$/m, 'codex_hooks = true');
+  } else if (/^\[features\]\s*$/m.test(text)) {
+    text = text.replace(/^\[features\]\s*$/m, '[features]\ncodex_hooks = true');
+  } else {
+    const sep = text.length > 0 && !text.endsWith('\n') ? '\n' : '';
+    text += `${sep}\n[features]\ncodex_hooks = true\n`;
+  }
+
+  try {
+    const dir = path.dirname(configPath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+    const tmpPath = configPath + '.pixel-agents-tmp';
+    fs.writeFileSync(tmpPath, text, 'utf-8');
+    fs.renameSync(tmpPath, configPath);
+    console.log('[Pixel Agents] Enabled codex_hooks in ~/.codex/config.toml');
+  } catch (e) {
+    console.error(`[Pixel Agents] Failed to write Codex config.toml: ${e}`);
+  }
+}
+
+function isOurHookEntry(entry: CodexHookEntry): boolean {
+  return entry.hooks.some((h) => h.command.includes(HOOK_SCRIPT_MARKER));
+}
+
+function makeHookCommand(): string {
+  return `node "${getHookScriptPath()}"`;
+}
+
+function makeHookEntry(matcher?: string): CodexHookEntry {
+  return {
+    ...(matcher !== undefined ? { matcher } : {}),
+    hooks: [{ type: 'command', command: makeHookCommand(), timeout: 5 }],
+  };
+}
+
+/** PreToolUse/PostToolUse are Bash-only on Codex today, so matcher is 'Bash'
+ *  rather than the catch-all empty matcher Claude uses. */
+function matcherFor(event: string): string | undefined {
+  if (event === 'PreToolUse' || event === 'PostToolUse') return 'Bash';
+  return undefined;
+}
+
+export function areHooksInstalled(): boolean {
+  const hooksFile = readCodexHooks();
+  if (!hooksFile.hooks) return false;
+  return CODEX_HOOK_EVENTS.every((event) => {
+    const entries = hooksFile.hooks?.[event];
+    return Array.isArray(entries) && entries.some(isOurHookEntry);
+  });
+}
+
+/** Install Pixel Agents hook entries into ~/.codex/hooks.json and flip the
+ *  codex_hooks feature flag on. Idempotent: replaces any existing Pixel
+ *  Agents entries so a changed script path self-heals. */
+export function installHooks(): void {
+  ensureCodexHooksFeatureFlag();
+
+  const hooksFile = readCodexHooks();
+  if (!hooksFile.hooks) hooksFile.hooks = {};
+
+  let changed = false;
+  for (const event of CODEX_HOOK_EVENTS) {
+    if (!Array.isArray(hooksFile.hooks[event])) {
+      hooksFile.hooks[event] = [];
+    }
+    const entries = hooksFile.hooks[event];
+    const filtered = entries.filter((e) => !isOurHookEntry(e));
+    filtered.push(makeHookEntry(matcherFor(event)));
+    if (JSON.stringify(filtered) !== JSON.stringify(entries)) {
+      hooksFile.hooks[event] = filtered;
+      changed = true;
+    }
+  }
+
+  if (changed) {
+    writeCodexHooks(hooksFile);
+    console.log('[Pixel Agents] Hooks installed in ~/.codex/hooks.json');
+  }
+}
+
+export function uninstallHooks(): void {
+  const hooksFile = readCodexHooks();
+  if (!hooksFile.hooks) return;
+
+  let changed = false;
+  for (const event of Object.keys(hooksFile.hooks)) {
+    const entries = hooksFile.hooks[event];
+    if (!Array.isArray(entries)) continue;
+    const filtered = entries.filter((e) => !isOurHookEntry(e));
+    if (filtered.length !== entries.length) {
+      hooksFile.hooks[event] = filtered;
+      changed = true;
+    }
+    if (hooksFile.hooks[event].length === 0) {
+      delete hooksFile.hooks[event];
+    }
+  }
+  if (Object.keys(hooksFile.hooks).length === 0) {
+    delete hooksFile.hooks;
+  }
+
+  if (changed) {
+    writeCodexHooks(hooksFile);
+    console.log('[Pixel Agents] Hooks removed from ~/.codex/hooks.json');
+  }
+  // Feature flag intentionally left as-is on uninstall: the user (or another
+  // tool) may have enabled codex_hooks for reasons unrelated to Pixel Agents.
+}
+
+/** Copy the shipped hook script from the extension/CLI dist to ~/.pixel-agents/hooks/ */
+export function copyHookScript(extensionPath: string): void {
+  const src = path.join(extensionPath, 'dist', 'hooks', CODEX_HOOK_SCRIPT_NAME);
+  const dst = getHookScriptPath();
+  const dstDir = path.dirname(dst);
+
+  try {
+    if (!fs.existsSync(dstDir)) {
+      fs.mkdirSync(dstDir, { recursive: true, mode: 0o700 });
+    }
+    if (!fs.existsSync(src)) {
+      console.warn(`[Pixel Agents] Codex hook script not found at ${src}`);
+      return;
+    }
+    fs.copyFileSync(src, dst);
+    fs.chmodSync(dst, 0o700);
+    console.log(`[Pixel Agents] Codex hook script installed at ${dst}`);
+  } catch (e) {
+    console.error(`[Pixel Agents] Failed to copy Codex hook script: ${e}`);
+  }
+}

--- a/server/src/providers/hook/codex/constants.ts
+++ b/server/src/providers/hook/codex/constants.ts
@@ -1,0 +1,25 @@
+/**
+ * Codex-specific constants. Kept separate from `server/src/constants.ts` so a
+ * future single-provider `server/` build doesn't accidentally depend on Codex
+ * unless Codex is an active provider.
+ */
+
+/** Output filename after esbuild compiles codex-hook.ts to CJS. */
+export const CODEX_HOOK_SCRIPT_NAME = 'codex-hook.js';
+
+/** Hook events to install in ~/.codex/hooks.json.
+ *  Codex's hooks system is experimental (feature-flagged) and only supports
+ *  these 5 events today: SessionStart (session lifecycle), PreToolUse/PostToolUse
+ *  (Bash only), UserPromptSubmit, Stop (turn completion). No subagent, file-write,
+ *  or notification events exist yet -- see docs/research at pixel-agents-hq for
+ *  the upstream gap list. */
+export const CODEX_HOOK_EVENTS = [
+  'SessionStart',
+  'Stop',
+  'PreToolUse',
+  'PostToolUse',
+  'UserPromptSubmit',
+] as const;
+
+/** Terminal name prefix used when launching Codex in VS Code (heuristic adoption). */
+export const CODEX_TERMINAL_NAME_PREFIX = 'Codex';

--- a/server/src/providers/hook/codex/hooks/codex-hook.ts
+++ b/server/src/providers/hook/codex/hooks/codex-hook.ts
@@ -1,0 +1,60 @@
+import * as fs from 'fs';
+import * as http from 'http';
+import * as os from 'os';
+import * as path from 'path';
+
+import { HOOK_API_PREFIX, SERVER_JSON_DIR, SERVER_JSON_NAME } from '../../../../constants.js';
+import type { ServerConfig } from '../../../../server.js';
+
+const SERVER_JSON = path.join(os.homedir(), SERVER_JSON_DIR, SERVER_JSON_NAME);
+
+async function main(): Promise<void> {
+  let input = '';
+  for await (const chunk of process.stdin) input += chunk;
+
+  let data: Record<string, unknown>;
+  try {
+    data = JSON.parse(input);
+  } catch {
+    process.exit(0);
+  }
+
+  let server: ServerConfig;
+  try {
+    server = JSON.parse(fs.readFileSync(SERVER_JSON, 'utf-8'));
+  } catch {
+    process.exit(0);
+  }
+
+  const body = JSON.stringify(data);
+  return new Promise((resolve) => {
+    const req = http.request(
+      {
+        hostname: '127.0.0.1',
+        port: server.port,
+        path: `${HOOK_API_PREFIX}/codex`,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(body),
+          Authorization: `Bearer ${server.token}`,
+        },
+        timeout: 2000,
+      },
+      (res) => {
+        res.resume();
+        resolve();
+      },
+    );
+    req.on('error', () => resolve());
+    req.on('timeout', () => {
+      req.destroy();
+      resolve();
+    });
+    req.end(body);
+  });
+}
+
+main()
+  .catch(() => {})
+  .finally(() => process.exit(0));

--- a/server/src/providers/index.ts
+++ b/server/src/providers/index.ts
@@ -13,3 +13,5 @@
 
 export { claudeProvider } from './hook/claude/claude.js';
 export { copyHookScript } from './hook/claude/claudeHookInstaller.js';
+export { codexProvider } from './hook/codex/codex.js';
+export { copyHookScript as copyCodexHookScript } from './hook/codex/codexHookInstaller.js';


### PR DESCRIPTION
## Summary

Adds a minimal `HookProvider` for OpenAI Codex CLI, following the single-subdirectory pattern documented in CLAUDE.md (`server/src/providers/hook/codex/`).

Codex's hooks system is experimental (feature-flagged off by default) and only fires 5 events today: `SessionStart`, `PreToolUse`/`PostToolUse` (Bash only), `UserPromptSubmit`, `Stop`. The payload shares `hook_event_name`/`session_id`/`cwd` field names with Claude Code's, so this is a straightforward normalization boundary, not a new event taxonomy.

Given Codex's current coverage, scope is intentionally small: no subagent events, no file-write hooks, no heuristic/transcript-polling fallback (Codex exposes no transcript file pixel-agents could poll). A Codex session shows up as an office character that goes active on Bash calls and idle on Stop — presence + turn-end, not full Claude-level tool-by-tool detail.

## What changed

- `server/src/providers/hook/codex/` — provider (`codex.ts`), installer (`codexHookInstaller.ts`), hook script (`hooks/codex-hook.ts`). Mirrors the Claude provider's structure.
- Installer writes to `~/.codex/hooks.json` additively (merges into existing hook entries, doesn't overwrite) and flips the `codex_hooks` feature flag in `config.toml` via a targeted single-line edit — no new TOML dependency, deliberately limited to the common single top-level `[features]` table case.
- **Runtime change** (the one non-additive part): `HookEventHandler` previously hardwired a single `HookProvider` per instance — the `providerId` param on `handleEvent` was received but unused (`_providerId`). Added an optional `secondaryProviders: HookProvider[]` list so `AgentRuntime`/`HookEventHandler` can normalize events from a second provider without touching the primary provider's team/tool-display logic (which Codex doesn't use). `cli.ts` passes `[codexProvider]` only when `~/.codex` exists, so machines without Codex never get a `~/.codex/` directory created.
- `esbuild.js`: bundles the new hook script to `dist/hooks/codex-hook.js` alongside the existing Claude one (switched from a single multi-entry `outdir` build, which nested output under `claude/hooks/`/`codex/hooks/`, to per-entry `outfile` builds so both stay flat).
- `server/__tests__/codex.test.ts` — unit coverage for `normalizeHookEvent` (all 5 events + unknown/malformed input) and `formatToolStatus` reuse.

## Testing

- Full server suite: 227/227 passing (213 existing + 14 new), no regressions.
- `npm run build` clean (typecheck, lint, asyncapi drift check, e2e inventory drift check all pass).
- Manual end-to-end smoke test against a running standalone server: POSTed a `SessionStart` then `Stop` event through the built `codex-hook.js` script and confirmed a live agent was created in the running instance's state.
- Ran the installer against my own real `~/.codex/hooks.json`, which already had several unrelated hooks configured (a Bash-deny guard, a Gmail notifier, a response-quality gate, some `supacode`-managed entries) — confirmed it merged in additively and left every existing entry untouched.

## Known gap (pre-existing, not introduced here)

While testing, I found the standalone CLI's `copyHookScript(distRoot)` call passes `dist/` as `extensionPath`, but `copyHookScript` joins `extensionPath + 'dist' + 'hooks'`, producing a `dist/dist/hooks/...` miss on first run (`"Hook script not found at .../dist/dist/hooks/claude-hook.js"`). This affects the existing Claude provider too, not just Codex — happy to send a separate small fix if useful, kept out of this PR to stay scoped to Codex support.

## Not attempted

Codex offers no equivalent to Claude's Agent Teams, subagent lifecycle, or file-write hooks today, so no `TeamProvider`, no `getSessionDirs`/heuristic fallback, and no subagent visualization for Codex sessions. Happy to extend if/when Codex's hooks API grows that coverage.