### PR TITLE
Add Hermes Agent and Codex CLI providers (multi-provider runtime support)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,4 +49,5 @@ agent-orchestrator.yaml
 # Agent-orchestrator / tooling scaffolding
 .ao/
 .serena/
-tasks/
+tasks/__pycache__/
+*.pyc

--- a/adapters/vscode/PixelAgentsViewProvider.ts
+++ b/adapters/vscode/PixelAgentsViewProvider.ts
@@ -164,7 +164,7 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
     });
 
     // Create shared runtime (owns timer Maps, scanners, hook handler, dismissal tracker)
-    this.runtime = new AgentRuntime(this.store, claudeProvider);
+    this.runtime = new AgentRuntime(this.store, [claudeProvider]);
 
     this.initServer();
   }

--- a/esbuild.js
+++ b/esbuild.js
@@ -63,6 +63,27 @@ function buildHooks() {
 }
 
 /**
+ * Copy the Hermes plugin's Python source (not TypeScript -- no bundling needed,
+ * it runs inside Hermes's own venv) into dist/hooks/ alongside the compiled
+ * Claude hook script, so both ship in the npm tarball's dist/hooks/ allowlist entry.
+ */
+function copyHermesPlugin() {
+  const src = path.join(
+    __dirname,
+    'server',
+    'src',
+    'providers',
+    'hook',
+    'hermes',
+    'pixel_agents_bridge_plugin.py',
+  );
+  if (!fs.existsSync(src)) return;
+  fs.mkdirSync(path.join(__dirname, 'dist', 'hooks'), { recursive: true });
+  fs.copyFileSync(src, path.join(__dirname, 'dist', 'hooks', 'pixel_agents_bridge_plugin.py'));
+  console.log('✓ Copied hermes plugin → dist/hooks/pixel_agents_bridge_plugin.py');
+}
+
+/**
  * @type {import('esbuild').Plugin}
  */
 const esbuildProblemMatcherPlugin = {
@@ -108,6 +129,7 @@ async function main() {
     // Copy assets and hooks after build
     copyAssets();
     buildHooks();
+    copyHermesPlugin();
     await buildCli();
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1830,9 +1830,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1850,9 +1847,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1870,9 +1864,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1890,9 +1881,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1910,9 +1898,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1930,9 +1915,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1950,9 +1932,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1970,9 +1949,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2185,9 +2161,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2202,9 +2175,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2219,9 +2189,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2236,9 +2203,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2253,9 +2217,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2270,9 +2231,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2287,9 +2245,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2304,9 +2259,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2555,9 +2507,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2575,9 +2524,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2595,9 +2541,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2615,9 +2558,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2635,9 +2575,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2655,9 +2592,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3296,9 +3230,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3316,9 +3247,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3336,9 +3264,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3356,9 +3281,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7650,9 +7572,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7674,9 +7593,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7698,9 +7614,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7722,9 +7635,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11418,7 +11328,7 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@tailwindcss/vite": "^4.2.2",
-        "@types/node": "26.x",
+        "@types/node": "^26.1.1",
         "@types/pngjs": "^6.0.5",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "dist/cli.js",
     "dist/extension.js",
     "dist/hooks/claude-hook.js",
+    "dist/hooks/pixel_agents_bridge_plugin.py",
     "dist/assets/",
     "dist/webview/",
     "icon.png"

--- a/server/__tests__/agentRuntime.multiProvider.test.ts
+++ b/server/__tests__/agentRuntime.multiProvider.test.ts
@@ -1,0 +1,159 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { AgentRuntime } from '../src/agentRuntime.js';
+import { AgentStateStore } from '../src/agentStateStore.js';
+import { claudeProvider } from '../src/providers/hook/claude/claude.js';
+import { codexProvider } from '../src/providers/hook/codex/codex.js';
+import { hermesProvider } from '../src/providers/hook/hermes/hermes.js';
+
+/**
+ * Covers the multi-provider routing patch in agentRuntime.ts: one HookEventHandler
+ * per provider, sharing a single AgentStateStore/office, routed by providerId.
+ */
+describe('AgentRuntime -- multi-provider routing', () => {
+  let runtime: AgentRuntime;
+  let store: AgentStateStore;
+
+  afterEach(() => {
+    runtime?.dispose();
+    vi.useRealTimers();
+  });
+
+  function trackedDir(prefix: string): string {
+    const dir = path.join(os.tmpdir(), `pxl-multi-${prefix}-${crypto.randomUUID()}`);
+    fs.mkdirSync(dir, { recursive: true });
+    return dir;
+  }
+
+  it('drops an event from an unregistered providerId without throwing', () => {
+    store = new AgentStateStore();
+    runtime = new AgentRuntime(store, [claudeProvider, hermesProvider, codexProvider]);
+    expect(() =>
+      runtime.handleHookEvent('some-unknown-provider', {
+        hook_event_name: 'SessionStart',
+        session_id: 'x',
+      }),
+    ).not.toThrow();
+    expect(store.size).toBe(0);
+  });
+
+  // A bare SessionStart only stores a *pending* external session (guards against
+  // Claude Code Extension's SessionStart+SessionEnd-with-no-activity noise, per
+  // hookEventHandler.ts); it takes a second "confirmation" event on the same
+  // session_id before an agent actually appears in the store. Every test below
+  // sends that follow-up event deliberately, matching real hook traffic.
+
+  it('routes Hermes and Codex sessions into the same store as distinct agents, tagged with their own providerId', () => {
+    store = new AgentStateStore();
+    runtime = new AgentRuntime(store, [claudeProvider, hermesProvider, codexProvider]);
+    runtime.watchAllSessions.current = true; // bypass the project-dir tracking gate for this test
+
+    const hermesDir = trackedDir('hermes');
+    const codexDir = trackedDir('codex');
+
+    runtime.handleHookEvent('hermes', {
+      hook_event_name: 'SessionStart',
+      session_id: 'hermes-sess-1',
+      cwd: hermesDir,
+    });
+    runtime.handleHookEvent('hermes', { hook_event_name: 'TurnEnd', session_id: 'hermes-sess-1' });
+    runtime.handleHookEvent('codex', {
+      hook_event_name: 'SessionStart',
+      session_id: 'codex-sess-1',
+      cwd: codexDir,
+    });
+    runtime.handleHookEvent('codex', { hook_event_name: 'TurnEnd', session_id: 'codex-sess-1' });
+
+    expect(store.size).toBe(2);
+    const providerIds = [...store.values()].map((a) => a.providerId).sort();
+    expect(providerIds).toEqual(['codex', 'hermes']);
+  });
+
+  it('duplicate SessionStart for the same providerId+session does not create a second agent', () => {
+    store = new AgentStateStore();
+    runtime = new AgentRuntime(store, [claudeProvider, hermesProvider, codexProvider]);
+    runtime.watchAllSessions.current = true;
+    const dir = trackedDir('dup');
+
+    runtime.handleHookEvent('hermes', {
+      hook_event_name: 'SessionStart',
+      session_id: 'hermes-dup-1',
+      cwd: dir,
+    });
+    runtime.handleHookEvent('hermes', { hook_event_name: 'TurnEnd', session_id: 'hermes-dup-1' });
+    expect(store.size).toBe(1);
+
+    // A second SessionStart for an already-known session_id is a no-op, not a
+    // fresh pending adoption (matches Claude's "known" SessionStart branch).
+    runtime.handleHookEvent('hermes', {
+      hook_event_name: 'SessionStart',
+      session_id: 'hermes-dup-1',
+      cwd: dir,
+    });
+    expect(store.size).toBe(1);
+  });
+
+  it('a Hermes toolStart/toolEnd pair does not affect a concurrent Codex agent in the same store', () => {
+    store = new AgentStateStore();
+    runtime = new AgentRuntime(store, [claudeProvider, hermesProvider, codexProvider]);
+    runtime.watchAllSessions.current = true;
+    const hermesDir = trackedDir('hermes2');
+    const codexDir = trackedDir('codex2');
+
+    runtime.handleHookEvent('hermes', {
+      hook_event_name: 'SessionStart',
+      session_id: 'h-1',
+      cwd: hermesDir,
+    });
+    runtime.handleHookEvent('codex', {
+      hook_event_name: 'SessionStart',
+      session_id: 'c-1',
+      cwd: codexDir,
+    });
+    // Confirm Codex first with a no-op TurnEnd so it's adopted but has no tool activity.
+    runtime.handleHookEvent('codex', { hook_event_name: 'TurnEnd', session_id: 'c-1' });
+    // Confirm + drive Hermes via ExecStart (confirms the pending session AND
+    // delivers the tool start in the same call -- see hookEventHandler.ts's
+    // confirmPending -> re-process-this-event flow).
+    runtime.handleHookEvent('hermes', {
+      hook_event_name: 'ExecStart',
+      session_id: 'h-1',
+      tool_id: 't1',
+      tool_name: 'terminal',
+      tool_input: { command: 'ls' },
+    });
+
+    const codexAgent = [...store.values()].find((a) => a.providerId === 'codex');
+    const hermesAgent = [...store.values()].find((a) => a.providerId === 'hermes');
+    expect(codexAgent?.hadToolsInTurn).toBe(false);
+    expect(codexAgent?.currentHookToolName).toBeUndefined();
+    expect(hermesAgent?.hadToolsInTurn).toBe(true);
+    expect(hermesAgent?.currentHookToolName).toBe('terminal');
+  });
+
+  it('malformed events (missing fields, wrong types) are dropped, never throw, and never create an agent', () => {
+    store = new AgentStateStore();
+    runtime = new AgentRuntime(store, [claudeProvider, hermesProvider, codexProvider]);
+    const malformed: Array<Record<string, unknown>> = [
+      {},
+      { hook_event_name: 123, session_id: 'x' },
+      { hook_event_name: 'SessionStart', session_id: null },
+      { hook_event_name: 'ExecStart', session_id: 'x', tool_id: 42 },
+    ];
+    for (const event of malformed) {
+      expect(() => runtime.handleHookEvent('hermes', event)).not.toThrow();
+      expect(() => runtime.handleHookEvent('codex', event)).not.toThrow();
+    }
+    expect(store.size).toBe(0);
+  });
+
+  it('dispose() tears down every provider handler without throwing', () => {
+    store = new AgentStateStore();
+    runtime = new AgentRuntime(store, [claudeProvider, hermesProvider, codexProvider]);
+    expect(() => runtime.dispose()).not.toThrow();
+  });
+});

--- a/server/__tests__/agentRuntime.restorePalette.test.ts
+++ b/server/__tests__/agentRuntime.restorePalette.test.ts
@@ -101,7 +101,7 @@ describe('AgentRuntime -- restore preserves palette/hueShift', () => {
     ];
     const store = new AgentStateStore();
     store.setAdapter(createMockAdapter(persisted));
-    runtime = new AgentRuntime(store, claudeProvider);
+    runtime = new AgentRuntime(store, [claudeProvider]);
 
     runtime.restoreExternalAgents();
 
@@ -117,7 +117,7 @@ describe('AgentRuntime -- restore preserves palette/hueShift', () => {
     const storeA = new AgentStateStore();
     const adapterA = createMockAdapter();
     storeA.setAdapter(adapterA);
-    runtime = new AgentRuntime(storeA, claudeProvider);
+    runtime = new AgentRuntime(storeA, [claudeProvider]);
     storeA.set(
       42,
       createTestAgent({
@@ -147,7 +147,7 @@ describe('AgentRuntime -- restore preserves palette/hueShift', () => {
     // wrote. The new adapter hands back exactly what phase 1 persisted.
     const storeB = new AgentStateStore();
     storeB.setAdapter(createMockAdapter(persisted));
-    runtime = new AgentRuntime(storeB, claudeProvider);
+    runtime = new AgentRuntime(storeB, [claudeProvider]);
     runtime.restoreExternalAgents();
 
     const restored = storeB.get(42);
@@ -170,7 +170,7 @@ describe('AgentRuntime -- restore preserves palette/hueShift', () => {
     ];
     const store = new AgentStateStore();
     store.setAdapter(createMockAdapter(persisted));
-    runtime = new AgentRuntime(store, claudeProvider);
+    runtime = new AgentRuntime(store, [claudeProvider]);
 
     runtime.restoreExternalAgents();
 

--- a/server/__tests__/agentRuntime.test.ts
+++ b/server/__tests__/agentRuntime.test.ts
@@ -51,7 +51,7 @@ describe('AgentRuntime -- D5 foreign-session gate', () => {
 
   it('drops a foreign session (unowned dir, watchAllSessions off): no agent created', () => {
     store = new AgentStateStore();
-    runtime = new AgentRuntime(store, claudeProvider);
+    runtime = new AgentRuntime(store, [claudeProvider]);
     // watchAllSessions defaults to false; this dir was never scanned/owned
     // by this instance -- exactly the "other server's session" scenario
     // fan-out introduces.
@@ -61,7 +61,7 @@ describe('AgentRuntime -- D5 foreign-session gate', () => {
 
   it('adopts a foreign session when watchAllSessions is on', () => {
     store = new AgentStateStore();
-    runtime = new AgentRuntime(store, claudeProvider);
+    runtime = new AgentRuntime(store, [claudeProvider]);
     runtime.watchAllSessions.current = true;
     fireSessionStartThenStop('d5-foreign-on', untrackedDir());
     expect(store.size).toBe(1);
@@ -69,7 +69,7 @@ describe('AgentRuntime -- D5 foreign-session gate', () => {
 
   it('adopts a session under a project dir this instance has scanned, even with watchAllSessions off', () => {
     store = new AgentStateStore();
-    runtime = new AgentRuntime(store, claudeProvider);
+    runtime = new AgentRuntime(store, [claudeProvider]);
     const dir = untrackedDir();
     runtime.startProjectScan(dir); // marks `dir` as owned/tracked
     fireSessionStartThenStop('d5-tracked-dir', dir);

--- a/server/__tests__/backgroundAgents.test.ts
+++ b/server/__tests__/backgroundAgents.test.ts
@@ -665,7 +665,7 @@ describe('background spawn persistence & derived team lifecycle', () => {
 
   it('drops the LEAD badge when the last teammate leaves', () => {
     const store = new AgentStateStore();
-    const runtime = new AgentRuntime(store, claudeProvider);
+    const runtime = new AgentRuntime(store, [claudeProvider]);
     try {
       const lead = createLeadAgent('/tmp/proj');
       lead.isTeamLead = true;
@@ -693,7 +693,7 @@ describe('background spawn persistence & derived team lifecycle', () => {
 
   it('keeps the LEAD badge while other teammates remain', () => {
     const store = new AgentStateStore();
-    const runtime = new AgentRuntime(store, claudeProvider);
+    const runtime = new AgentRuntime(store, [claudeProvider]);
     try {
       const lead = createLeadAgent('/tmp/proj');
       lead.isTeamLead = true;
@@ -751,7 +751,7 @@ describe('background spawn persistence & derived team lifecycle', () => {
 
     const store = new AgentStateStore();
     store.setAdapter(adapter);
-    const runtime = new AgentRuntime(store, claudeProvider);
+    const runtime = new AgentRuntime(store, [claudeProvider]);
     try {
       runtime.restoreExternalAgents();
 

--- a/server/__tests__/codex.test.ts
+++ b/server/__tests__/codex.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+
+import { codexProvider } from '../src/providers/hook/codex/codex.js';
+
+describe('codexProvider', () => {
+  describe('identity', () => {
+    it('has kind "hook"', () => {
+      expect(codexProvider.kind).toBe('hook');
+    });
+    it('has id "codex"', () => {
+      expect(codexProvider.id).toBe('codex');
+    });
+    it('has a displayName', () => {
+      expect(codexProvider.displayName).toBe('Codex CLI');
+    });
+    it('has protocolVersion 1', () => {
+      expect(codexProvider.protocolVersion).toBe(1);
+    });
+    it('has no subagent tools (Codex has no delegation concept today)', () => {
+      expect(codexProvider.subagentToolNames.size).toBe(0);
+    });
+  });
+
+  describe('normalizeHookEvent', () => {
+    it('returns null when hook_event_name is missing', () => {
+      expect(codexProvider.normalizeHookEvent({ session_id: 'x' })).toBeNull();
+    });
+    it('returns null when session_id is missing', () => {
+      expect(codexProvider.normalizeHookEvent({ hook_event_name: 'SessionStart' })).toBeNull();
+    });
+    it('returns null for an unknown hook_event_name (forward-compat, never throws)', () => {
+      expect(
+        codexProvider.normalizeHookEvent({ hook_event_name: 'SomeFutureEvent', session_id: 's1' }),
+      ).toBeNull();
+    });
+    it('maps SessionStart -> sessionStart with cwd/transcriptPath', () => {
+      const result = codexProvider.normalizeHookEvent({
+        hook_event_name: 'SessionStart',
+        session_id: 's1',
+        cwd: '/tmp/proj',
+        transcript_path: '/home/user/.codex/sessions/2026/01/01/rollout-x.jsonl',
+      });
+      expect(result).toEqual({
+        sessionId: 's1',
+        event: {
+          kind: 'sessionStart',
+          cwd: '/tmp/proj',
+          transcriptPath: '/home/user/.codex/sessions/2026/01/01/rollout-x.jsonl',
+        },
+      });
+    });
+
+    it('maps SessionEnd -> sessionEnd with reason', () => {
+      const result = codexProvider.normalizeHookEvent({
+        hook_event_name: 'SessionEnd',
+        session_id: 's1',
+        reason: 'idle-timeout',
+      });
+      expect(result?.event).toEqual({ kind: 'sessionEnd', reason: 'idle-timeout' });
+    });
+
+    it('maps ExecStart -> toolStart with toolId/toolName/input', () => {
+      const result = codexProvider.normalizeHookEvent({
+        hook_event_name: 'ExecStart',
+        session_id: 's1',
+        tool_id: 'call_abc',
+        tool_name: 'exec_command',
+        tool_input: { cmd: 'ls' },
+      });
+      expect(result?.event).toEqual({
+        kind: 'toolStart',
+        toolId: 'call_abc',
+        toolName: 'exec_command',
+        input: { cmd: 'ls' },
+      });
+    });
+
+    it('maps ExecEnd -> toolEnd, keyed by the matching call_id', () => {
+      const result = codexProvider.normalizeHookEvent({
+        hook_event_name: 'ExecEnd',
+        session_id: 's1',
+        tool_id: 'call_abc',
+      });
+      expect(result?.event).toEqual({ kind: 'toolEnd', toolId: 'call_abc' });
+    });
+
+    it('ExecEnd falls back to toolId "current" when tool_id is missing', () => {
+      const result = codexProvider.normalizeHookEvent({
+        hook_event_name: 'ExecEnd',
+        session_id: 's1',
+      });
+      expect(result?.event).toEqual({ kind: 'toolEnd', toolId: 'current' });
+    });
+
+    it('maps TurnEnd -> turnEnd (never awaitingInput -- Codex has no distinct idle signal)', () => {
+      const result = codexProvider.normalizeHookEvent({
+        hook_event_name: 'TurnEnd',
+        session_id: 's1',
+      });
+      expect(result?.event).toEqual({ kind: 'turnEnd' });
+    });
+  });
+
+  describe('formatToolStatus', () => {
+    it('formats exec_command with the command text', () => {
+      expect(codexProvider.formatToolStatus('exec_command', { cmd: 'ls -la' })).toBe(
+        'Running: ls -la',
+      );
+    });
+    it('classifies apply_patch as a write-style tool (not in readingTools)', () => {
+      expect(codexProvider.readingTools.has('apply_patch')).toBe(false);
+      expect(codexProvider.formatToolStatus('apply_patch')).toBe('Editing files');
+    });
+    it('classifies read_file/web_search as reading tools', () => {
+      expect(codexProvider.readingTools.has('read_file')).toBe(true);
+      expect(codexProvider.readingTools.has('web_search')).toBe(true);
+    });
+    it('falls back to the raw tool name for unrecognized tools', () => {
+      expect(codexProvider.formatToolStatus('some_future_tool')).toBe('Using some_future_tool');
+    });
+  });
+});

--- a/server/__tests__/hermes.test.ts
+++ b/server/__tests__/hermes.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+
+import { hermesProvider } from '../src/providers/hook/hermes/hermes.js';
+
+describe('hermesProvider', () => {
+  describe('identity', () => {
+    it('has kind "hook"', () => {
+      expect(hermesProvider.kind).toBe('hook');
+    });
+    it('has id "hermes"', () => {
+      expect(hermesProvider.id).toBe('hermes');
+    });
+    it('has a displayName', () => {
+      expect(hermesProvider.displayName).toBe('Hermes Agent');
+    });
+    it('has protocolVersion 1', () => {
+      expect(hermesProvider.protocolVersion).toBe(1);
+    });
+  });
+
+  describe('normalizeHookEvent', () => {
+    it('returns null when hook_event_name is missing', () => {
+      expect(hermesProvider.normalizeHookEvent({ session_id: 'x' })).toBeNull();
+    });
+    it('returns null when session_id is missing', () => {
+      expect(hermesProvider.normalizeHookEvent({ hook_event_name: 'SessionStart' })).toBeNull();
+    });
+    it('returns null for an unknown event name (forward-compat, never throws)', () => {
+      expect(
+        hermesProvider.normalizeHookEvent({
+          hook_event_name: 'FutureHermesEvent',
+          session_id: 's1',
+        }),
+      ).toBeNull();
+    });
+
+    it('maps SessionStart -> sessionStart', () => {
+      const result = hermesProvider.normalizeHookEvent({
+        hook_event_name: 'SessionStart',
+        session_id: 's1',
+        cwd: '/home/user/project',
+      });
+      expect(result?.event).toEqual({ kind: 'sessionStart', cwd: '/home/user/project' });
+    });
+
+    it('maps SessionEnd (on_session_finalize) -> sessionEnd', () => {
+      const result = hermesProvider.normalizeHookEvent({
+        hook_event_name: 'SessionEnd',
+        session_id: 's1',
+        reason: 'finalize',
+      });
+      expect(result?.event).toEqual({ kind: 'sessionEnd', reason: 'finalize' });
+    });
+
+    it('maps TurnEnd (on_session_end, which fires per-turn in Hermes) -> turnEnd', () => {
+      const result = hermesProvider.normalizeHookEvent({
+        hook_event_name: 'TurnEnd',
+        session_id: 's1',
+        awaiting_input: true,
+      });
+      expect(result?.event).toEqual({ kind: 'turnEnd', awaitingInput: true });
+    });
+
+    it('TurnEnd defaults awaitingInput to false when not interrupted', () => {
+      const result = hermesProvider.normalizeHookEvent({
+        hook_event_name: 'TurnEnd',
+        session_id: 's1',
+      });
+      expect(result?.event).toEqual({ kind: 'turnEnd', awaitingInput: false });
+    });
+
+    it('maps ExecStart (pre_tool_call) -> toolStart', () => {
+      const result = hermesProvider.normalizeHookEvent({
+        hook_event_name: 'ExecStart',
+        session_id: 's1',
+        tool_id: 'call_1',
+        tool_name: 'terminal',
+        tool_input: { command: 'echo hi' },
+      });
+      expect(result?.event).toEqual({
+        kind: 'toolStart',
+        toolId: 'call_1',
+        toolName: 'terminal',
+        input: { command: 'echo hi' },
+      });
+    });
+
+    it('maps ExecEnd (post_tool_call) -> toolEnd', () => {
+      const result = hermesProvider.normalizeHookEvent({
+        hook_event_name: 'ExecEnd',
+        session_id: 's1',
+        tool_id: 'call_1',
+      });
+      expect(result?.event).toEqual({ kind: 'toolEnd', toolId: 'call_1' });
+    });
+
+    it('maps SubagentStart -> subagentStart keyed by child_session_id', () => {
+      const result = hermesProvider.normalizeHookEvent({
+        hook_event_name: 'SubagentStart',
+        session_id: 'lead-1',
+        child_session_id: 'child-1',
+        agent_type: 'researcher',
+        goal: 'find docs',
+      });
+      expect(result).toEqual({
+        sessionId: 'lead-1',
+        event: {
+          kind: 'subagentStart',
+          parentToolId: 'current',
+          toolId: 'child-1',
+          toolName: 'researcher',
+          input: 'find docs',
+        },
+      });
+    });
+
+    it('maps SubagentStop -> subagentEnd keyed by the same child_session_id', () => {
+      const result = hermesProvider.normalizeHookEvent({
+        hook_event_name: 'SubagentStop',
+        session_id: 'lead-1',
+        child_session_id: 'child-1',
+      });
+      expect(result).toEqual({
+        sessionId: 'lead-1',
+        event: { kind: 'subagentEnd', parentToolId: 'current', toolId: 'child-1' },
+      });
+    });
+  });
+
+  describe('formatToolStatus', () => {
+    it('formats terminal/run_command/shell with the command text', () => {
+      expect(hermesProvider.formatToolStatus('terminal', { command: 'ls' })).toBe('Running: ls');
+    });
+    it('formats mcp__ prefixed tools using the server-local name', () => {
+      expect(hermesProvider.formatToolStatus('mcp__supabase__list_tables')).toBe(
+        'Using list_tables',
+      );
+    });
+    it('falls back to the raw tool name for unrecognized tools', () => {
+      expect(hermesProvider.formatToolStatus('some_future_tool')).toBe('Using some_future_tool');
+    });
+  });
+});

--- a/server/src/agentRuntime.ts
+++ b/server/src/agentRuntime.ts
@@ -82,27 +82,51 @@ export class AgentRuntime {
   readonly dismissalTracker = new DismissalTracker();
   /** Shadow-store watcher for unnamed background spawns (sub-agents). */
   readonly subagentWatch: SubagentWatch;
-  private hookEventHandler: HookEventHandler;
+  /** One HookEventHandler per registered provider, keyed by HookProvider.id ('claude',
+   *  'hermes', 'codex', ...). Each handler is scoped to exactly one provider so there is
+   *  no shared mutable "current provider" field -- concurrent events from different
+   *  providers can never race each other. All handlers share this runtime's
+   *  store/timers/SessionRouter seam so every provider's agents render in one office. */
+  private readonly hookEventHandlers = new Map<string, HookEventHandler>();
+  /** id of providers[0] (Claude by convention). Default target for call sites that
+   *  predate multi-provider support and don't know their agent's providerId. */
+  private readonly primaryProviderId: string;
   private lifecycleCallbacks: RuntimeLifecycleCallbacks = {};
 
   constructor(
     private readonly store: AgentStateStore,
-    provider: HookProvider,
+    providers: HookProvider[],
   ) {
-    // Wire module-level dependencies
+    if (providers.length === 0) {
+      throw new Error('AgentRuntime requires at least one HookProvider');
+    }
+    // The primary provider (first in the list, Claude by convention) owns the
+    // module-level file-watcher/team-resolution singletons in fileWatcher.ts and
+    // transcriptParser.ts. Those singletons predate multi-provider support and are
+    // only consulted by the project-dir/external JSONL scanners -- the scanning
+    // heuristic Claude uses when hooks aren't installed. Providers that never rely
+    // on that scanner (Hermes: live hook push; Codex: its own JSONL tailer that
+    // POSTs synthesized events) don't need it, so binding it to providers[0] only
+    // preserves Claude's exact existing behavior with zero risk of cross-provider
+    // interference.
+    const [primaryProvider] = providers;
+    this.primaryProviderId = primaryProvider.id;
     setDismissalTracker(this.dismissalTracker);
-    setHookProvider(provider);
-    setFileWatcherHookProvider(provider);
+    setHookProvider(primaryProvider);
+    setFileWatcherHookProvider(primaryProvider);
     this.subagentWatch = new SubagentWatch(store);
     setSubagentWatch(this.subagentWatch);
-    if (provider.team) {
-      setTeamProvider(provider.team);
+    if (primaryProvider.team) {
+      setTeamProvider(primaryProvider.team);
     }
     setAgentRemovalCallback((id) => this.removeAgent(id));
     setTeammateRemovalCallback((id) => this.removeTeammate(id, 'team-config'));
     // New-style teammates run their own sessions; registering routes their hook
     // events (PreToolUse, Stop, SessionEnd) directly to the teammate agent.
-    setTeammateRegisterCallback((sessionId, agentId) => this.registerAgent(sessionId, agentId));
+    // Teams are a primary-provider-only feature (Claude Agent Teams today).
+    setTeammateRegisterCallback((sessionId, agentId) =>
+      this.registerAgent(sessionId, agentId, primaryProvider.id),
+    );
     // Background spawns (teams OFF): classify by sidecar name on spawn (named
     // -> teammate character, unnamed -> shadow-watched sub-agent), remove when
     // the completion queue-operation lands on the lead.
@@ -142,142 +166,155 @@ export class AgentRuntime {
       }
     });
 
-    this.hookEventHandler = new HookEventHandler(
-      store,
-      this.waitingTimers,
-      this.permissionTimers,
-      provider,
-      new SessionRouter(),
-      this.watchAllSessions,
-    );
+    // One HookEventHandler + SessionRouter per provider, all sharing this runtime's
+    // store/timer Maps so agents from every provider render in the same office.
+    for (const provider of providers) {
+      const handler = new HookEventHandler(
+        store,
+        this.waitingTimers,
+        this.permissionTimers,
+        provider,
+        new SessionRouter(),
+        this.watchAllSessions,
+      );
+      this.hookEventHandlers.set(provider.id, handler);
 
-    // Wire hook lifecycle callbacks to shared agent operations
-    this.hookEventHandler.setLifecycleCallbacks({
-      onExternalSessionDetected: (sessionId, transcriptPath, cwd) => {
-        const projectDir = transcriptPath ? path.dirname(transcriptPath) : cwd;
-        // Teammate session of a tracked lead? Attach it as a teammate character
-        // instead of adopting a generic external agent -- and regardless of the
-        // Watch All Sessions setting: tracking the lead is the opt-in for its
-        // team. (Newer harnesses run every spawned agent as an independent
-        // top-level session that fires its own hooks.)
-        if (transcriptPath) {
-          const teamMeta = provider.team?.getTeamMetadataForSession(transcriptPath);
-          if (teamMeta?.teamName && teamMeta.agentName) {
-            for (const [leadId, lead] of this.store) {
-              if (lead.teamName !== teamMeta.teamName || lead.leadAgentId !== undefined) continue;
-              console.log(
-                `[Pixel Agents] Hook: session ${sessionId.slice(0, 8)}... is teammate "${teamMeta.agentName}" of Agent ${leadId}, attaching`,
-              );
-              scanForTeammateFiles(
-                lead.projectDir,
-                lead.sessionId,
-                leadId,
-                this.store.nextAgentId,
-                this.store,
-                this.fileWatchers,
-                this.pollingTimers,
-                this.waitingTimers,
-                this.permissionTimers,
-                () => this.store.persist(),
-                undefined,
-              );
-              break;
-            }
-            // Done only if discovery actually adopted this transcript. Old-style
-            // tmux teammates (non-UUID transcript names outside discovery's scan)
-            // fall through to normal external adoption and self-identify from
-            // their record tags.
-            for (const a of this.store.values()) {
-              if (pathsMatch(a.jsonlFile, transcriptPath)) return;
+      // Wire hook lifecycle callbacks to shared agent operations
+      handler.setLifecycleCallbacks({
+        onExternalSessionDetected: (sessionId, transcriptPath, cwd) => {
+          const projectDir = transcriptPath ? path.dirname(transcriptPath) : cwd;
+          // Teammate session of a tracked lead? Attach it as a teammate character
+          // instead of adopting a generic external agent -- and regardless of the
+          // Watch All Sessions setting: tracking the lead is the opt-in for its
+          // team. (Newer harnesses run every spawned agent as an independent
+          // top-level session that fires its own hooks.)
+          if (transcriptPath) {
+            const teamMeta = provider.team?.getTeamMetadataForSession(transcriptPath);
+            if (teamMeta?.teamName && teamMeta.agentName) {
+              for (const [leadId, lead] of this.store) {
+                if (lead.teamName !== teamMeta.teamName || lead.leadAgentId !== undefined) continue;
+                console.log(
+                  `[Pixel Agents] Hook: session ${sessionId.slice(0, 8)}... is teammate "${teamMeta.agentName}" of Agent ${leadId}, attaching`,
+                );
+                scanForTeammateFiles(
+                  lead.projectDir,
+                  lead.sessionId,
+                  leadId,
+                  this.store.nextAgentId,
+                  this.store,
+                  this.fileWatchers,
+                  this.pollingTimers,
+                  this.waitingTimers,
+                  this.permissionTimers,
+                  () => this.store.persist(),
+                  undefined,
+                );
+                break;
+              }
+              // Done only if discovery actually adopted this transcript. Old-style
+              // tmux teammates (non-UUID transcript names outside discovery's scan)
+              // fall through to normal external adoption and self-identify from
+              // their record tags.
+              for (const a of this.store.values()) {
+                if (pathsMatch(a.jsonlFile, transcriptPath)) return;
+              }
             }
           }
-        }
-        if (!isTrackedProjectDir(projectDir) && !this.watchAllSessions.current) {
-          console.log(
-            `[Pixel Agents] Hook: external session ${sessionId.slice(0, 8)}... not adopted ` +
-              `(project untracked, Watch All Sessions off)`,
-          );
-          return;
-        }
-        adoptExternalSessionFromHook(
-          sessionId,
-          transcriptPath,
-          cwd,
-          this.knownJsonlFiles,
-          this.store.nextAgentId,
-          this.store,
-          this.fileWatchers,
-          this.pollingTimers,
-          this.waitingTimers,
-          this.permissionTimers,
-          () => this.store.persist(),
-          (agent) => this.registerAgent(agent.sessionId, agent.id),
-        );
-      },
-      onSessionClear: (agentId, newSessionId, newTranscriptPath) => {
-        if (newTranscriptPath) {
-          this.knownJsonlFiles.add(newTranscriptPath);
-          reassignAgentToFile(
-            agentId,
-            newTranscriptPath,
+          if (!isTrackedProjectDir(projectDir) && !this.watchAllSessions.current) {
+            console.log(
+              `[Pixel Agents] Hook: external session ${sessionId.slice(0, 8)}... not adopted ` +
+                `(project untracked, Watch All Sessions off)`,
+            );
+            return;
+          }
+          adoptExternalSessionFromHook(
+            sessionId,
+            transcriptPath,
+            cwd,
+            this.knownJsonlFiles,
+            this.store.nextAgentId,
             this.store,
             this.fileWatchers,
             this.pollingTimers,
             this.waitingTimers,
             this.permissionTimers,
             () => this.store.persist(),
+            (agent) => {
+              // adoptExternalSessionFromHook predates multi-provider support and
+              // never stamps providerId; without this, every non-primary-provider
+              // agent's later unregisterAgent/removeAgent calls would default to
+              // the primary provider's handler and silently leak a stale
+              // SessionRouter entry in the correct one.
+              agent.providerId = provider.id;
+              this.registerAgent(agent.sessionId, agent.id, provider.id);
+            },
           );
-        }
-        const agent = this.store.get(agentId);
-        if (agent) {
-          this.unregisterAgent(agent.sessionId);
-          agent.sessionId = newSessionId;
-          this.registerAgent(agent.sessionId, agent.id);
-        }
-      },
-      onSessionResume: (transcriptPath) => {
-        this.dismissalTracker.clearDismissal(transcriptPath);
-        this.dismissalTracker.clearSeededMtime(transcriptPath);
-        this.knownJsonlFiles.delete(transcriptPath);
-      },
-      onTeammateDetected: (parentAgentId, sessionId, _agentType) => {
-        const parentAgent = this.store.get(parentAgentId);
-        if (!parentAgent) return;
-        scanForTeammateFiles(
-          parentAgent.projectDir,
-          sessionId,
-          parentAgentId,
-          this.store.nextAgentId,
-          this.store,
-          this.fileWatchers,
-          this.pollingTimers,
-          this.waitingTimers,
-          this.permissionTimers,
-          () => this.store.persist(),
-          // Don't register inline teammates: they share the lead's sessionId
-          // and registering them would overwrite the lead in the session router.
-          undefined,
-        );
-      },
-      onTeammateRemoved: (teammateAgentId) => {
-        this.removeTeammate(teammateAgentId, 'hooks');
-      },
-      onSessionEnd: (agentId) => {
-        const agent = this.store.get(agentId);
-        if (!agent) return;
-        this.dismissalTracker.clearSeededMtime(agent.jsonlFile);
-        this.dismissalTracker.dismiss(agent.jsonlFile);
-        // Covers real team leads AND leads of background teammates (which
-        // have children but no teamName). No-op when childless.
-        this.removeTeammates(agentId);
-        // Unnamed background spawns die with their lead's session too.
-        this.subagentWatch.removeByLead(agentId);
-        if (agent.isExternal) {
-          this.unregisterAgent(agent.sessionId);
-          this.removeAgent(agentId);
-        }
-      },
-    });
+        },
+        onSessionClear: (agentId, newSessionId, newTranscriptPath) => {
+          if (newTranscriptPath) {
+            this.knownJsonlFiles.add(newTranscriptPath);
+            reassignAgentToFile(
+              agentId,
+              newTranscriptPath,
+              this.store,
+              this.fileWatchers,
+              this.pollingTimers,
+              this.waitingTimers,
+              this.permissionTimers,
+              () => this.store.persist(),
+            );
+          }
+          const agent = this.store.get(agentId);
+          if (agent) {
+            this.unregisterAgent(agent.sessionId, provider.id);
+            agent.sessionId = newSessionId;
+            this.registerAgent(agent.sessionId, agent.id, provider.id);
+          }
+        },
+        onSessionResume: (transcriptPath) => {
+          this.dismissalTracker.clearDismissal(transcriptPath);
+          this.dismissalTracker.clearSeededMtime(transcriptPath);
+          this.knownJsonlFiles.delete(transcriptPath);
+        },
+        onTeammateDetected: (parentAgentId, sessionId, _agentType) => {
+          const parentAgent = this.store.get(parentAgentId);
+          if (!parentAgent) return;
+          scanForTeammateFiles(
+            parentAgent.projectDir,
+            sessionId,
+            parentAgentId,
+            this.store.nextAgentId,
+            this.store,
+            this.fileWatchers,
+            this.pollingTimers,
+            this.waitingTimers,
+            this.permissionTimers,
+            () => this.store.persist(),
+            // Don't register inline teammates: they share the lead's sessionId
+            // and registering them would overwrite the lead in the session router.
+            undefined,
+          );
+        },
+        onTeammateRemoved: (teammateAgentId) => {
+          this.removeTeammate(teammateAgentId, 'hooks');
+        },
+        onSessionEnd: (agentId) => {
+          const agent = this.store.get(agentId);
+          if (!agent) return;
+          this.dismissalTracker.clearSeededMtime(agent.jsonlFile);
+          this.dismissalTracker.dismiss(agent.jsonlFile);
+          // Covers real team leads AND leads of background teammates (which
+          // have children but no teamName). No-op when childless.
+          this.removeTeammates(agentId);
+          // Unnamed background spawns die with their lead's session too.
+          this.subagentWatch.removeByLead(agentId);
+          if (agent.isExternal) {
+            this.unregisterAgent(agent.sessionId, provider.id);
+            this.removeAgent(agentId);
+          }
+        },
+      });
+    }
   }
 
   /** Register adapter-specific lifecycle callbacks. */
@@ -287,19 +324,33 @@ export class AgentRuntime {
 
   // ── Hook event routing ──
 
-  /** Route an incoming hook event to the appropriate agent. */
+  /** Route an incoming hook event to the handler for the provider that sent it. Drops
+   *  the event (with a log) if providerId doesn't match any registered provider --
+   *  this is the only place an unknown providerId can surface, since the HTTP layer
+   *  accepts any :providerId in the URL. */
   handleHookEvent(providerId: string, event: Record<string, unknown>): void {
-    this.hookEventHandler.handleEvent(providerId, event as HookEvent);
+    const handler = this.hookEventHandlers.get(providerId);
+    if (!handler) {
+      console.warn(`[Pixel Agents] Dropping event from unknown provider "${providerId}"`);
+      return;
+    }
+    handler.handleEvent(providerId, event as HookEvent);
   }
 
-  /** Register an agent with the hook event handler for session->agent mapping. */
-  registerAgent(sessionId: string, agentId: number): void {
-    this.hookEventHandler.registerAgent(sessionId, agentId);
+  /** Register an agent with its provider's hook event handler for session->agent
+   *  mapping. providerId defaults to the primary provider for call sites that predate
+   *  multi-provider support (all of which are Claude-only scan/restore paths). */
+  registerAgent(
+    sessionId: string,
+    agentId: number,
+    providerId: string = this.primaryProviderId,
+  ): void {
+    this.hookEventHandlers.get(providerId)?.registerAgent(sessionId, agentId);
   }
 
-  /** Unregister an agent from the hook event handler. */
-  unregisterAgent(sessionId: string): void {
-    this.hookEventHandler.unregisterAgent(sessionId);
+  /** Unregister an agent from its provider's hook event handler. */
+  unregisterAgent(sessionId: string, providerId: string = this.primaryProviderId): void {
+    this.hookEventHandlers.get(providerId)?.unregisterAgent(sessionId);
   }
 
   // ── Agent removal (shared cleanup) ──
@@ -346,7 +397,7 @@ export class AgentRuntime {
     // Background teammates (spawnToolUseId set) share the LEAD's session id;
     // unregistering it would knock the lead itself out of the session router.
     if (!agent.spawnToolUseId) {
-      this.unregisterAgent(agent.sessionId);
+      this.unregisterAgent(agent.sessionId, agent.providerId);
     }
     this.lifecycleCallbacks.onTeammateRemoved?.(teammateId, agent, source);
     this.removeAgent(teammateId);
@@ -390,7 +441,7 @@ export class AgentRuntime {
         console.log(`[Pixel Agents] Removing teammate ${id} (lead ${leadId} closed)`);
         this.dismissalTracker.dismiss(agent.jsonlFile);
         if (!agent.spawnToolUseId) {
-          this.unregisterAgent(agent.sessionId);
+          this.unregisterAgent(agent.sessionId, agent.providerId);
         }
         this.removeAgent(id);
       }
@@ -539,7 +590,7 @@ export class AgentRuntime {
         /* ignore stat errors on restore */
       }
 
-      this.registerAgent(agent.sessionId, agent.id);
+      this.registerAgent(agent.sessionId, agent.id, agent.providerId);
 
       if (p.id > maxId) maxId = p.id;
       console.log(
@@ -558,7 +609,9 @@ export class AgentRuntime {
 
   /** Clean up all scanners, timers, and agents. Called on shutdown. */
   dispose(): void {
-    this.hookEventHandler.dispose();
+    for (const handler of this.hookEventHandlers.values()) {
+      handler.dispose();
+    }
     this.subagentWatch.dispose();
 
     if (this.projectScanTimer.current) {

--- a/server/src/cli.ts
+++ b/server/src/cli.ts
@@ -22,8 +22,19 @@ import type { AssetCache, ReloadAssetsSideEffect } from './clientMessageHandler.
 import { readConfig } from './configPersistence.js';
 import { MAX_PORT, MIN_PORT } from './constants.js';
 import { FileStateAdapter } from './fileStateAdapter.js';
-import { claudeProvider, copyHookScript } from './providers/index.js';
+import { copyHermesPlugin } from './providers/hook/hermes/hermesHookInstaller.js';
+import {
+  claudeProvider,
+  codexProvider,
+  copyHookScript,
+  hermesProvider,
+} from './providers/index.js';
 import { PixelAgentsServer } from './server.js';
+
+/** All providers this standalone server hosts, sharing one office. Claude stays
+ *  first: AgentRuntime treats providers[0] as primary for its file-scanning
+ *  singletons and legacy (no-providerId) call sites -- see agentRuntime.ts. */
+const ALL_PROVIDERS = [claudeProvider, hermesProvider, codexProvider];
 
 // ── Argument parsing ──────────────────────────────────────────
 
@@ -115,12 +126,64 @@ async function main(): Promise<void> {
 
   try {
     // Create runtime first (before server.start, so we can pass it in)
-    const runtime = new AgentRuntime(store, claudeProvider);
+    const runtime = new AgentRuntime(store, ALL_PROVIDERS);
 
     // Wire hook events: HTTP POST -> runtime -> hookEventHandler -> agents
     server.onHookEvent((providerId, event) => {
       runtime.handleHookEvent(providerId, event);
     });
+
+    // Installs/uninstalls every provider's hooks together. Claude and Hermes each
+    // need a file copied into place first (compiled hook script / plugin source);
+    // Codex has nothing to copy -- installHooks() just starts its in-process
+    // JSONL tailer. A failure in one provider's install is logged and does not
+    // block the others (graceful degradation: one broken provider can't take
+    // down hook delivery for the rest).
+    const installAllHooks = async (serverUrl: string, authToken: string): Promise<void> => {
+      const copied = copyHookScript(packageRoot);
+      try {
+        await claudeProvider.installHooks(serverUrl, authToken);
+        console.log(
+          copied
+            ? '[Pixel Agents] Claude hooks installed'
+            : '[Pixel Agents] Claude hooks NOT installed, hook script missing',
+        );
+      } catch (err) {
+        console.error('[Pixel Agents] Failed to install Claude hooks:', err);
+      }
+      try {
+        const pluginCopied = copyHermesPlugin(packageRoot);
+        await hermesProvider.installHooks(serverUrl, authToken);
+        console.log(
+          pluginCopied
+            ? '[Pixel Agents] Hermes plugin installed (applies to Hermes sessions started from now on -- see README for the already-running-session limitation)'
+            : '[Pixel Agents] Hermes plugin NOT installed, plugin source missing',
+        );
+      } catch (err) {
+        console.error('[Pixel Agents] Failed to install Hermes plugin:', err);
+      }
+      try {
+        await codexProvider.installHooks(serverUrl, authToken);
+        console.log('[Pixel Agents] Codex JSONL tailer started');
+      } catch (err) {
+        console.error('[Pixel Agents] Failed to start Codex tailer:', err);
+      }
+    };
+
+    const uninstallAllHooks = async (): Promise<void> => {
+      await Promise.all([
+        claudeProvider
+          .uninstallHooks()
+          .catch((err) => console.error('[Pixel Agents] Failed to uninstall Claude hooks:', err)),
+        hermesProvider
+          .uninstallHooks()
+          .catch((err) => console.error('[Pixel Agents] Failed to uninstall Hermes plugin:', err)),
+        codexProvider
+          .uninstallHooks()
+          .catch((err) => console.error('[Pixel Agents] Failed to stop Codex tailer:', err)),
+      ]);
+      console.log('[Pixel Agents] Hooks uninstalled');
+    };
 
     // onSetHooksEnabled side effect: install/uninstall hooks when user toggles in UI.
     // Captures config from the outer scope after server.start().
@@ -128,19 +191,9 @@ async function main(): Promise<void> {
     const onSetHooksEnabled = async (enabled: boolean): Promise<void> => {
       if (!currentConfig) return;
       if (enabled) {
-        await claudeProvider.installHooks(
-          `http://127.0.0.1:${currentConfig.port}`,
-          currentConfig.token,
-        );
-        const copied = copyHookScript(packageRoot);
-        console.log(
-          copied
-            ? '[Pixel Agents] Hooks installed (user toggle)'
-            : '[Pixel Agents] Hooks NOT installed (user toggle), hook script missing',
-        );
+        await installAllHooks(`http://127.0.0.1:${currentConfig.port}`, currentConfig.token);
       } else {
-        await claudeProvider.uninstallHooks();
-        console.log('[Pixel Agents] Hooks uninstalled (user toggle)');
+        await uninstallAllHooks();
       }
     };
 
@@ -200,17 +253,7 @@ async function main(): Promise<void> {
 
     // Install hooks on startup if the persisted setting says so
     if (runtime.hooksEnabled.current) {
-      try {
-        await claudeProvider.installHooks(`http://127.0.0.1:${config.port}`, config.token);
-        const copied = copyHookScript(packageRoot);
-        console.log(
-          copied
-            ? '[Pixel Agents] Hooks installed'
-            : '[Pixel Agents] Hooks NOT installed, hook script missing',
-        );
-      } catch (err) {
-        console.error('[Pixel Agents] Failed to install hooks:', err);
-      }
+      await installAllHooks(`http://127.0.0.1:${config.port}`, config.token);
     }
 
     // Start scanning for external sessions (Claude running in user's terminal)

--- a/server/src/providers/hook/codex/codex.ts
+++ b/server/src/providers/hook/codex/codex.ts
@@ -1,0 +1,139 @@
+import type { AgentEvent, HookProvider } from '../../../../../core/src/provider.js';
+import { BASH_COMMAND_DISPLAY_MAX_LENGTH } from '../../../constants.js';
+import { CodexTailer } from './codexTailer.js';
+import { CODEX_READING_TOOL_NAMES, CODEX_TERMINAL_NAME_PREFIX } from './constants.js';
+
+// ── formatToolStatus ──
+//
+// Codex's dominant tool is a general-purpose shell (`exec_command`); dedicated
+// tools like `read_file`/`web_search` are comparatively rare. Falls back to the
+// raw tool name for anything not special-cased, same as Claude's default arm.
+
+export function formatToolStatus(toolName: string, input?: unknown): string {
+  const inp = (input ?? {}) as Record<string, unknown>;
+  switch (toolName) {
+    case 'exec_command':
+    case 'shell': {
+      const cmd = (inp.cmd as string) || (inp.command as string) || '';
+      return `Running: ${cmd.length > BASH_COMMAND_DISPLAY_MAX_LENGTH ? cmd.slice(0, BASH_COMMAND_DISPLAY_MAX_LENGTH) + '…' : cmd}`;
+    }
+    case 'apply_patch':
+      return 'Editing files';
+    case 'read_file':
+      return `Reading ${typeof inp.path === 'string' ? inp.path : 'file'}`;
+    case 'web_search':
+      return 'Searching the web';
+    case 'view_image':
+      return 'Viewing image';
+    default:
+      return `Using ${toolName}`;
+  }
+}
+
+// ── normalizeHookEvent ──
+//
+// All raw fields from our own codexTailer.ts payloads (tool_id, tool_name, cwd,
+// transcript_path) are read HERE and HERE ONLY, mirroring claude.ts's boundary.
+// The tailer defines this vocabulary itself (SessionStart/ExecStart/ExecEnd/
+// TurnEnd/SessionEnd) since Codex has no hook-event names of its own to normalize.
+
+function normalizeHookEvent(
+  raw: Record<string, unknown>,
+): { sessionId: string; event: AgentEvent } | null {
+  const eventName = raw.hook_event_name;
+  const sessionId = raw.session_id;
+  if (typeof eventName !== 'string' || typeof sessionId !== 'string') return null;
+
+  switch (eventName) {
+    case 'SessionStart':
+      return {
+        sessionId,
+        event: {
+          kind: 'sessionStart',
+          transcriptPath: typeof raw.transcript_path === 'string' ? raw.transcript_path : undefined,
+          cwd: typeof raw.cwd === 'string' ? raw.cwd : undefined,
+        },
+      };
+
+    case 'SessionEnd':
+      return {
+        sessionId,
+        event: {
+          kind: 'sessionEnd',
+          reason: typeof raw.reason === 'string' ? raw.reason : undefined,
+        },
+      };
+
+    case 'ExecStart': {
+      const toolId = typeof raw.tool_id === 'string' ? raw.tool_id : `codex-${Date.now()}`;
+      const toolName = typeof raw.tool_name === 'string' ? raw.tool_name : 'exec_command';
+      return {
+        sessionId,
+        event: { kind: 'toolStart', toolId, toolName, input: raw.tool_input },
+      };
+    }
+
+    case 'ExecEnd': {
+      const toolId = typeof raw.tool_id === 'string' ? raw.tool_id : 'current';
+      return { sessionId, event: { kind: 'toolEnd', toolId } };
+    }
+
+    // Codex has no separate "went idle waiting for input" signal distinct from
+    // "finished its turn" -- task_complete covers both, so awaitingInput is
+    // always false here (renders as "Done", never "Waiting for input").
+    case 'TurnEnd':
+      return { sessionId, event: { kind: 'turnEnd' } };
+
+    default:
+      return null;
+  }
+}
+
+// ── Installer: starts/stops the in-process JSONL tailer ──
+
+let tailer: CodexTailer | null = null;
+
+function installHooks(serverUrl: string, authToken: string): Promise<void> {
+  if (!tailer) tailer = new CodexTailer(serverUrl, authToken);
+  tailer.start();
+  return Promise.resolve();
+}
+
+function uninstallHooks(): Promise<void> {
+  tailer?.stop();
+  return Promise.resolve();
+}
+
+function areHooksInstalled(): Promise<boolean> {
+  return Promise.resolve(tailer?.isRunning ?? false);
+}
+
+// ── The provider ──
+
+export const codexProvider: HookProvider = {
+  kind: 'hook',
+  id: 'codex',
+  displayName: 'Codex CLI',
+  protocolVersion: 1,
+
+  normalizeHookEvent,
+
+  installHooks,
+  uninstallHooks,
+  areHooksInstalled,
+
+  formatToolStatus,
+  // Codex has no built-in subagent/delegation concept exposed in the rollout
+  // format today, so no tool is exempt from permission timers and none spawns
+  // a sub-character. Revisit if/when Codex ships multi-agent delegation.
+  permissionExemptTools: new Set<string>(),
+  subagentToolNames: new Set<string>(),
+  readingTools: CODEX_READING_TOOL_NAMES,
+  terminalNamePrefix: CODEX_TERMINAL_NAME_PREFIX,
+};
+
+/** Exposed for tests: reset the module-level tailer singleton between runs. */
+export function __resetCodexTailerForTests(): void {
+  tailer?.stop();
+  tailer = null;
+}

--- a/server/src/providers/hook/codex/codexTailer.ts
+++ b/server/src/providers/hook/codex/codexTailer.ts
@@ -1,0 +1,307 @@
+/**
+ * Tails Codex CLI's structured JSONL session rollouts (~/.codex/sessions/**\/*.jsonl)
+ * and re-emits them as normalized hook events over the same POST /api/hooks/:providerId
+ * ingress a real hook script uses. Codex has no hooks/plugin API to install into, so
+ * this tailer *is* codexProvider.installHooks() -- it reads Codex's own structured
+ * session format rather than scraping terminal output.
+ *
+ * Runs entirely in-process (setInterval), owned by exactly one server instance, so
+ * unlike Claude's cross-process hook-script fan-out there is no multi-server registry
+ * to consult: the serverUrl/authToken passed to installHooks() are this server's own.
+ */
+
+import * as fs from 'fs';
+import * as http from 'http';
+import * as os from 'os';
+import * as path from 'path';
+
+import { HOOK_API_PREFIX } from '../../../constants.js';
+import {
+  CODEX_POLL_INTERVAL_MS,
+  CODEX_SESSION_STALE_MS,
+  CODEX_SESSIONS_DIRNAME,
+} from './constants.js';
+
+interface TrackedSession {
+  /** Falls back to the rollout filename until session_meta names the real Codex
+   *  session_id, so ExecStart/ExecEnd never lack a session_id to route on. */
+  sessionId: string;
+  offset: number;
+  lineBuffer: string;
+  cwd: string;
+  lastActivity: number;
+  sessionStartSent: boolean;
+  sessionEndSent: boolean;
+  /** call_id of the most recent unfinished function_call, so we can pair its
+   *  function_call_output with a toolEnd for the same id. */
+  openToolIds: Set<string>;
+}
+
+function postEvent(
+  serverUrl: string,
+  authToken: string,
+  body: Record<string, unknown>,
+): Promise<void> {
+  const json = JSON.stringify(body);
+  const url = new URL(`${HOOK_API_PREFIX}/codex`, serverUrl);
+  return new Promise((resolve) => {
+    const req = http.request(
+      {
+        hostname: url.hostname,
+        port: url.port,
+        path: url.pathname,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(json),
+          Authorization: `Bearer ${authToken}`,
+        },
+        timeout: 2000,
+      },
+      (res) => {
+        res.resume();
+        resolve();
+      },
+    );
+    req.on('error', () => resolve());
+    req.on('timeout', () => {
+      req.destroy();
+      resolve();
+    });
+    req.end(json);
+  });
+}
+
+/** Extract the codex-vscode/codex-cli JSON-schema `arguments` string into an object,
+ *  falling back to the raw string when it isn't valid JSON (never throw on user data). */
+function parseArgs(raw: unknown): unknown {
+  if (typeof raw !== 'string') return raw;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return { raw };
+  }
+}
+
+export class CodexTailer {
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private readonly sessions = new Map<string, TrackedSession>();
+  private readonly rootDir: string;
+
+  constructor(
+    private readonly serverUrl: string,
+    private readonly authToken: string,
+    rootDir?: string,
+  ) {
+    this.rootDir = rootDir ?? path.join(os.homedir(), '.codex', CODEX_SESSIONS_DIRNAME);
+  }
+
+  get isRunning(): boolean {
+    return this.timer !== null;
+  }
+
+  start(): void {
+    if (this.timer) return;
+    this.timer = setInterval(() => {
+      this.tick().catch(() => {
+        /* a single failed poll must never take down the interval */
+      });
+    }, CODEX_POLL_INTERVAL_MS);
+    this.timer.unref?.();
+  }
+
+  stop(): void {
+    if (this.timer) clearInterval(this.timer);
+    this.timer = null;
+    this.sessions.clear();
+  }
+
+  private async findRolloutFiles(): Promise<string[]> {
+    const results: string[] = [];
+    const walk = (dir: string, depth: number): void => {
+      if (depth > 4) return; // sessions/YYYY/MM/DD/*.jsonl
+      let entries: fs.Dirent[];
+      try {
+        entries = fs.readdirSync(dir, { withFileTypes: true });
+      } catch {
+        return;
+      }
+      for (const entry of entries) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) walk(full, depth + 1);
+        else if (entry.isFile() && entry.name.endsWith('.jsonl')) results.push(full);
+      }
+    };
+    walk(this.rootDir, 0);
+    return results;
+  }
+
+  private async tick(): Promise<void> {
+    const files = await this.findRolloutFiles();
+    const seen = new Set<string>();
+
+    for (const file of files) {
+      let stat: fs.Stats;
+      try {
+        stat = fs.statSync(file);
+      } catch {
+        continue;
+      }
+      // Skip files with no growth since last successful parse AND older than the
+      // poll window -- avoids re-reading thousands of historical rollouts every tick.
+      let tracked = this.sessions.get(file);
+      if (!tracked && stat.size === 0) continue;
+      if (!tracked && Date.now() - stat.mtimeMs > CODEX_SESSION_STALE_MS) continue; // pre-existing, inactive
+
+      if (!tracked) {
+        tracked = {
+          sessionId: path.basename(file),
+          offset: 0,
+          lineBuffer: '',
+          cwd: '',
+          lastActivity: Date.now(),
+          sessionStartSent: false,
+          sessionEndSent: false,
+          openToolIds: new Set(),
+        };
+        this.sessions.set(file, tracked);
+      }
+      seen.add(file);
+      if (stat.size < tracked.offset) {
+        // Truncated/rotated: restart from the top rather than throwing on a negative read.
+        tracked.offset = 0;
+        tracked.lineBuffer = '';
+      }
+      if (stat.size === tracked.offset) continue;
+
+      await this.readNewLines(file, tracked);
+    }
+
+    // Sessions whose file we didn't see this tick (deleted/rotated away) or that
+    // have gone quiet past the stale window: synthesize sessionEnd once. Codex's
+    // JSONL rollout never writes an explicit end-of-session record, so this is a
+    // heuristic close, not a real signal -- documented in constants.ts.
+    const now = Date.now();
+    for (const [file, tracked] of this.sessions) {
+      if (tracked.sessionEndSent) continue;
+      const stale = now - tracked.lastActivity > CODEX_SESSION_STALE_MS;
+      if (stale || !seen.has(file)) {
+        if (tracked.sessionStartSent) {
+          await this.emit(file, tracked, { hook_event_name: 'SessionEnd', reason: 'idle-timeout' });
+        }
+        tracked.sessionEndSent = true;
+      }
+    }
+    for (const [file, tracked] of this.sessions) {
+      if (tracked.sessionEndSent && now - tracked.lastActivity > CODEX_SESSION_STALE_MS * 2) {
+        this.sessions.delete(file);
+      }
+    }
+  }
+
+  private async readNewLines(file: string, tracked: TrackedSession): Promise<void> {
+    let chunk: string;
+    try {
+      const fd = fs.openSync(file, 'r');
+      const stat = fs.fstatSync(fd);
+      const length = stat.size - tracked.offset;
+      if (length <= 0) {
+        fs.closeSync(fd);
+        return;
+      }
+      const buf = Buffer.alloc(length);
+      fs.readSync(fd, buf, 0, length, tracked.offset);
+      fs.closeSync(fd);
+      tracked.offset = stat.size;
+      chunk = buf.toString('utf-8');
+    } catch {
+      return; // transient read error (mid-write); pick it up next tick
+    }
+
+    const combined = tracked.lineBuffer + chunk;
+    const lines = combined.split('\n');
+    tracked.lineBuffer = lines.pop() ?? ''; // last element may be a partial line
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      let record: Record<string, unknown>;
+      try {
+        record = JSON.parse(trimmed) as Record<string, unknown>;
+      } catch {
+        continue; // malformed/truncated line: skip, never crash the tailer
+      }
+      tracked.lastActivity = Date.now();
+      await this.handleRecord(file, tracked, record);
+    }
+  }
+
+  private async handleRecord(
+    file: string,
+    tracked: TrackedSession,
+    record: Record<string, unknown>,
+  ): Promise<void> {
+    const type = record.type;
+    const payload = (record.payload ?? {}) as Record<string, unknown>;
+
+    if (type === 'session_meta') {
+      const sessionId = (payload.session_id ?? payload.id) as string | undefined;
+      if (typeof sessionId !== 'string') return;
+      tracked.cwd = typeof payload.cwd === 'string' ? payload.cwd : '';
+      tracked.sessionId = sessionId;
+      if (!tracked.sessionStartSent) {
+        tracked.sessionStartSent = true;
+        await this.emit(file, tracked, {
+          hook_event_name: 'SessionStart',
+          cwd: tracked.cwd,
+          transcript_path: file,
+        });
+      }
+      return;
+    }
+
+    if (type === 'response_item' && payload.type === 'function_call') {
+      const callId = payload.call_id;
+      const name = payload.name;
+      if (typeof callId !== 'string' || typeof name !== 'string') return;
+      tracked.openToolIds.add(callId);
+      await this.emit(file, tracked, {
+        hook_event_name: 'ExecStart',
+        tool_id: callId,
+        tool_name: name,
+        tool_input: parseArgs(payload.arguments),
+      });
+      return;
+    }
+
+    if (type === 'response_item' && payload.type === 'function_call_output') {
+      const callId = payload.call_id;
+      if (typeof callId !== 'string') return;
+      tracked.openToolIds.delete(callId);
+      await this.emit(file, tracked, { hook_event_name: 'ExecEnd', tool_id: callId });
+      return;
+    }
+
+    if (
+      type === 'event_msg' &&
+      (payload.type === 'task_complete' || payload.type === 'turn_aborted')
+    ) {
+      await this.emit(file, tracked, { hook_event_name: 'TurnEnd' });
+      return;
+    }
+  }
+
+  /** All events for a session carry the rollout file's basename as session_id so the
+   *  runtime can distinguish concurrent Codex sessions across different projects. */
+  private async emit(
+    _file: string,
+    tracked: TrackedSession,
+    fields: Record<string, unknown>,
+  ): Promise<void> {
+    await postEvent(this.serverUrl, this.authToken, {
+      ...fields,
+      session_id: tracked.sessionId,
+      cwd: fields.cwd ?? tracked.cwd,
+    });
+  }
+}

--- a/server/src/providers/hook/codex/constants.ts
+++ b/server/src/providers/hook/codex/constants.ts
@@ -1,0 +1,33 @@
+/**
+ * Codex-specific constants. Kept separate from `server/src/constants.ts` so a
+ * future single-provider build doesn't accidentally depend on Codex unless
+ * Codex is the active provider.
+ */
+
+/** Codex CLI has no hooks/plugin API (confirmed against codex-cli 0.144.1: `codex
+ *  --help` lists no `hooks` subcommand, and there is no config.toml hook surface).
+ *  What it does expose is a structured, append-only JSONL rollout per session at
+ *  ~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl. This provider's "hook install"
+ *  is therefore a tailer that reads that structured JSONL and re-emits it through
+ *  the exact same POST /api/hooks/:providerId ingress a real hook script uses --
+ *  structured events, never terminal-output scraping. */
+export const CODEX_SESSIONS_DIRNAME = 'sessions';
+
+/** How often the tailer re-scans ~/.codex/sessions for new/changed files. */
+export const CODEX_POLL_INTERVAL_MS = 1500;
+
+/** A rollout file with no new bytes for this long is assumed abandoned (the
+ *  Codex process exited without an explicit end-of-session record -- JSONL
+ *  rollouts don't write one). This is a heuristic, not a real signal: it trades
+ *  a few extra minutes of a "Done" character for never leaving a stale one
+ *  forever. Documented in codex.ts. */
+export const CODEX_SESSION_STALE_MS = 10 * 60 * 1000;
+
+/** Codex `response_item` function_call names that read/search rather than write
+ *  or execute. Codex's primary tool is a general-purpose shell (`exec_command`),
+ *  so most reads and writes are indistinguishable at the tool-name level; this
+ *  list only covers the small set of dedicated read-style tools Codex exposes
+ *  outside the shell. */
+export const CODEX_READING_TOOL_NAMES = new Set(['read_file', 'view_image', 'web_search']);
+
+export const CODEX_TERMINAL_NAME_PREFIX = 'Codex';

--- a/server/src/providers/hook/hermes/constants.ts
+++ b/server/src/providers/hook/hermes/constants.ts
@@ -1,0 +1,37 @@
+/**
+ * Hermes-specific constants. Kept separate from `server/src/constants.ts` so a
+ * future single-provider build doesn't accidentally depend on Hermes unless
+ * Hermes is the active provider.
+ *
+ * Hermes Agent (v0.20.0, confirmed via `hermes --help` / `hermes plugins --help` /
+ * `hermes hooks --help` against a live install) has three separate hook systems:
+ *   - Gateway hooks (~/.hermes/hooks/) -- messaging-platform sessions ONLY
+ *     (Telegram/Discord/Slack/WhatsApp/Teams). Do NOT fire for CLI sessions.
+ *   - Shell hooks (hooks: block in config.yaml) -- CLI + gateway, but limited to a
+ *     small fixed set of directive events (pre_tool_call, subagent_stop,
+ *     on_session_finalize, ...) and invoked as external shell scripts.
+ *   - Plugin hooks (ctx.register_hook() in ~/.hermes/plugins/<name>/) -- CLI +
+ *     gateway, the full documented catalog (pre_tool_call, post_tool_call,
+ *     on_session_start, on_session_end, on_session_finalize, subagent_start,
+ *     subagent_stop, ...). This is the one that actually covers CLI sessions with
+ *     enough granularity to drive character animation, so it's what this provider
+ *     installs into.
+ *
+ * Plugin hooks only fire for sessions started *after* the plugin is loaded
+ * (Hermes discovers ~/.hermes/plugins/ once, at process start) -- an
+ * already-running `hermes` session cannot retroactively receive them.
+ */
+
+/** User-plugin directory (NOT the vendored ~/.hermes/hermes-agent/plugins/ tree --
+ *  writing there would mutate Hermes's own git checkout). Matches the documented
+ *  "User" plugin tier in plugins.md: "Drop a directory into ~/.hermes/plugins/". */
+export const HERMES_PLUGINS_DIRNAME = 'plugins';
+export const HERMES_PLUGIN_NAME = 'pixel-agents-bridge';
+export const HERMES_PLUGIN_MODULE_FILENAME = '__init__.py';
+
+/** Plugins are opt-in as of Hermes config schema v21+ (plugins.enabled allow-list
+ *  in ~/.hermes/config.yaml). `hermes plugins enable <name>` is the documented,
+ *  idempotent CLI for this -- used instead of hand-editing YAML. */
+export const HERMES_CLI_BIN = 'hermes';
+
+export const HERMES_TERMINAL_NAME_PREFIX = 'hermes';

--- a/server/src/providers/hook/hermes/hermes.ts
+++ b/server/src/providers/hook/hermes/hermes.ts
@@ -1,0 +1,159 @@
+import type { AgentEvent, HookProvider } from '../../../../../core/src/provider.js';
+import { BASH_COMMAND_DISPLAY_MAX_LENGTH } from '../../../constants.js';
+import { HERMES_TERMINAL_NAME_PREFIX } from './constants.js';
+import {
+  areHermesHooksInstalled,
+  installHermesHooks,
+  uninstallHermesHooks,
+} from './hermesHookInstaller.js';
+
+// ── formatToolStatus ──
+//
+// Hermes's tool surface is large and highly configurable (MCP servers, gateway
+// tools, cron, kanban, ...), so this only special-cases the common built-ins;
+// everything else falls back to the raw tool name, same pattern as Claude/Codex.
+
+export function formatToolStatus(toolName: string, input?: unknown): string {
+  const inp = (input ?? {}) as Record<string, unknown>;
+  switch (toolName) {
+    case 'terminal':
+    case 'run_command':
+    case 'shell': {
+      const cmd = (inp.command as string) || (inp.cmd as string) || '';
+      return `Running: ${cmd.length > BASH_COMMAND_DISPLAY_MAX_LENGTH ? cmd.slice(0, BASH_COMMAND_DISPLAY_MAX_LENGTH) + '…' : cmd}`;
+    }
+    case 'read_file':
+    case 'view_file':
+      return `Reading ${typeof inp.path === 'string' ? inp.path : 'file'}`;
+    case 'write_file':
+    case 'edit_file':
+      return `Editing ${typeof inp.path === 'string' ? inp.path : 'file'}`;
+    case 'web_search':
+      return 'Searching the web';
+    case 'web_fetch':
+      return 'Fetching web content';
+    default:
+      return toolName.startsWith('mcp__')
+        ? `Using ${toolName.split('__').pop()}`
+        : `Using ${toolName}`;
+  }
+}
+
+// ── normalizeHookEvent ──
+//
+// Raw fields come from pixel_agents_bridge_plugin.py's _emit() calls -- HERE and
+// HERE ONLY, mirroring claude.ts's and codex.ts's normalization boundary. That
+// plugin defines its own event vocabulary (SessionStart/ExecStart/ExecEnd/
+// TurnEnd/SessionEnd/SubagentStart/SubagentStop) mapped from Hermes's *documented*
+// plugin-hook catalog (see constants.ts) -- not invented, not scraped.
+
+function normalizeHookEvent(
+  raw: Record<string, unknown>,
+): { sessionId: string; event: AgentEvent } | null {
+  const eventName = raw.hook_event_name;
+  const sessionId = raw.session_id;
+  if (typeof eventName !== 'string' || typeof sessionId !== 'string') return null;
+
+  switch (eventName) {
+    case 'SessionStart':
+      return {
+        sessionId,
+        event: { kind: 'sessionStart', cwd: typeof raw.cwd === 'string' ? raw.cwd : undefined },
+      };
+
+    case 'SessionEnd':
+      return {
+        sessionId,
+        event: {
+          kind: 'sessionEnd',
+          reason: typeof raw.reason === 'string' ? raw.reason : undefined,
+        },
+      };
+
+    case 'ExecStart': {
+      const toolId = typeof raw.tool_id === 'string' ? raw.tool_id : `hermes-${Date.now()}`;
+      const toolName = typeof raw.tool_name === 'string' ? raw.tool_name : 'tool';
+      return {
+        sessionId,
+        event: { kind: 'toolStart', toolId, toolName, input: raw.tool_input },
+      };
+    }
+
+    case 'ExecEnd': {
+      const toolId = typeof raw.tool_id === 'string' ? raw.tool_id : 'current';
+      return { sessionId, event: { kind: 'toolEnd', toolId } };
+    }
+
+    // Hermes's on_session_end fires per-turn (see plugin docstring), so this is
+    // the turnEnd signal, not process exit -- SessionEnd (above) covers real
+    // teardown via on_session_finalize.
+    case 'TurnEnd':
+      return {
+        sessionId,
+        event: { kind: 'turnEnd', awaitingInput: raw.awaiting_input === true },
+      };
+
+    case 'SubagentStart': {
+      const childSessionId =
+        typeof raw.child_session_id === 'string' ? raw.child_session_id : `sub-${Date.now()}`;
+      const agentType = typeof raw.agent_type === 'string' ? raw.agent_type : 'subagent';
+      return {
+        sessionId,
+        event: {
+          kind: 'subagentStart',
+          parentToolId: 'current',
+          toolId: childSessionId,
+          toolName: agentType,
+          input: raw.goal,
+        },
+      };
+    }
+
+    case 'SubagentStop': {
+      const childSessionId =
+        typeof raw.child_session_id === 'string' ? raw.child_session_id : 'current';
+      return {
+        sessionId,
+        event: { kind: 'subagentEnd', parentToolId: 'current', toolId: childSessionId },
+      };
+    }
+
+    default:
+      return null;
+  }
+}
+
+// ── Installer wrappers ──
+
+function installHooks(_serverUrl: string, _authToken: string): Promise<void> {
+  return installHermesHooks();
+}
+
+function uninstallHooks(): Promise<void> {
+  return uninstallHermesHooks();
+}
+
+function areHooksInstalled(): Promise<boolean> {
+  return Promise.resolve(areHermesHooksInstalled());
+}
+
+// ── The provider ──
+
+export const hermesProvider: HookProvider = {
+  kind: 'hook',
+  id: 'hermes',
+  displayName: 'Hermes Agent',
+  protocolVersion: 1,
+
+  normalizeHookEvent,
+
+  installHooks,
+  uninstallHooks,
+  areHooksInstalled,
+
+  formatToolStatus,
+  permissionExemptTools: new Set<string>(),
+  subagentToolNames: new Set<string>(),
+  readingTools: new Set(['read_file', 'view_file', 'web_search', 'web_fetch']),
+  terminalNamePrefix: HERMES_TERMINAL_NAME_PREFIX,
+};

--- a/server/src/providers/hook/hermes/hermesHookInstaller.ts
+++ b/server/src/providers/hook/hermes/hermesHookInstaller.ts
@@ -1,0 +1,81 @@
+/**
+ * Installs/removes the pixel-agents-bridge Hermes plugin under ~/.hermes/plugins/.
+ * See constants.ts for why the plugin-hook system (not gateway hooks or shell hooks)
+ * is the correct integration point, and why this only affects Hermes sessions
+ * started after installation.
+ */
+
+import { execFile } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import {
+  HERMES_CLI_BIN,
+  HERMES_PLUGIN_MODULE_FILENAME,
+  HERMES_PLUGIN_NAME,
+  HERMES_PLUGINS_DIRNAME,
+} from './constants.js';
+
+function hermesHome(): string {
+  return process.env.HERMES_HOME || path.join(os.homedir(), '.hermes');
+}
+
+function pluginDir(): string {
+  return path.join(hermesHome(), HERMES_PLUGINS_DIRNAME, HERMES_PLUGIN_NAME);
+}
+
+const PLUGIN_YAML = `name: ${HERMES_PLUGIN_NAME}
+version: 1.0.0
+description: "Forwards Hermes plugin-hook activity (tool calls, session lifecycle, subagents) to a running Pixel Agents office (POST /api/hooks/hermes). Installed and managed by pixel-office; safe to remove at any time with \`hermes plugins remove ${HERMES_PLUGIN_NAME}\`."
+author: "pixel-office"
+hooks:
+  - on_session_start
+  - pre_tool_call
+  - post_tool_call
+  - on_session_end
+  - on_session_finalize
+  - subagent_start
+  - subagent_stop
+`;
+
+function runHermesCli(args: string[]): Promise<void> {
+  return new Promise((resolve) => {
+    // Best-effort: a missing/broken `hermes` binary must not crash the Pixel Agents
+    // server. Worst case the plugin file exists on disk but isn't in the
+    // plugins.enabled allow-list yet -- areHooksInstalled() below reports that
+    // honestly rather than lying about success.
+    execFile(HERMES_CLI_BIN, args, { timeout: 15_000 }, () => resolve());
+  });
+}
+
+/** Copies the bundled plugin source into ~/.hermes/plugins/. Mirrors
+ *  copyHookScript(packageRoot) for Claude: cli.ts passes packageRoot (the npm
+ *  package root at runtime, dist/.. ) since the compiled dist/ layout -- not the
+ *  TypeScript source tree -- is what actually ships in the npm tarball.
+ *  Returns false (and copies nothing) if the bundled source is missing. */
+export function copyHermesPlugin(packageRoot: string): boolean {
+  const source = path.join(packageRoot, 'dist', 'hooks', 'pixel_agents_bridge_plugin.py');
+  if (!fs.existsSync(source)) return false;
+  const dir = pluginDir();
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'plugin.yaml'), PLUGIN_YAML, 'utf-8');
+  fs.copyFileSync(source, path.join(dir, HERMES_PLUGIN_MODULE_FILENAME));
+  return true;
+}
+
+/** Enables the plugin in ~/.hermes/config.yaml via the documented `hermes plugins
+ *  enable` CLI (idempotent -- safe to call even if already enabled). Assumes
+ *  copyHermesPlugin() already placed the plugin directory on disk. */
+export async function installHermesHooks(): Promise<void> {
+  await runHermesCli(['plugins', 'enable', HERMES_PLUGIN_NAME]);
+}
+
+export async function uninstallHermesHooks(): Promise<void> {
+  await runHermesCli(['plugins', 'disable', HERMES_PLUGIN_NAME]);
+  fs.rmSync(pluginDir(), { recursive: true, force: true });
+}
+
+export function areHermesHooksInstalled(): boolean {
+  return fs.existsSync(path.join(pluginDir(), HERMES_PLUGIN_MODULE_FILENAME));
+}

--- a/server/src/providers/hook/hermes/pixel_agents_bridge_plugin.py
+++ b/server/src/providers/hook/hermes/pixel_agents_bridge_plugin.py
@@ -1,0 +1,178 @@
+"""pixel_agents_bridge — forwards Hermes plugin-hook activity to Pixel Agents.
+
+Installed by codexProvider's sibling, hermesProvider.installHooks(), by copying this
+file (unmodified) to ~/.hermes/hermes-agent/plugins/pixel_agents_bridge/__init__.py
+alongside a generated plugin.yaml. Hermes discovers it via HookRegistry.discover_and_load()
+on its next process start -- per Hermes's plugin-hook docs, plugin hooks fire in both
+CLI and gateway sessions, but only for sessions started *after* the plugin is loaded.
+A session already running when this file is installed will not see it until restarted.
+
+Mirrors claude-hook.ts's multi-server registry fan-out: reads every live server
+record from ~/.pixel-agents/servers/*.json (skipping dead PIDs) and POSTs to all of
+them, since a plugin hook fires in a separate OS process from any pixel-agents
+server instance, unlike Codex's in-process tailer.
+
+Failure mode: silent and best-effort throughout, exactly like every other Hermes
+hook handler -- a dead or unreachable pixel-agents server must never affect the
+Hermes session it's instrumenting. urllib only (stdlib), so no extra dependency
+enters Hermes's venv for a purely-optional integration.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.request
+from pathlib import Path
+from typing import Any, Dict
+
+_HOOK_API_PATH = "/api/hooks/hermes"
+_TIMEOUT_S = 2.0
+
+
+def _registry_dir() -> Path:
+    return Path.home() / ".pixel-agents" / "servers"
+
+
+def _is_pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Process exists but is owned by someone else -- still alive.
+        return True
+    except Exception:
+        return False
+    return True
+
+
+def _live_servers() -> list[Dict[str, Any]]:
+    directory = _registry_dir()
+    servers: list[Dict[str, Any]] = []
+    try:
+        entries = list(directory.glob("*.json"))
+    except Exception:
+        return servers
+    for entry in entries:
+        try:
+            data = json.loads(entry.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        pid = data.get("pid")
+        port = data.get("port")
+        token = data.get("token")
+        if not isinstance(pid, int) or not isinstance(port, int) or not isinstance(token, str):
+            continue
+        if not _is_pid_alive(pid):
+            continue
+        servers.append(data)
+    return servers
+
+
+def _post(server: Dict[str, Any], body: bytes) -> None:
+    url = f"http://127.0.0.1:{server['port']}{_HOOK_API_PATH}"
+    req = urllib.request.Request(
+        url,
+        data=body,
+        method="POST",
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {server['token']}",
+        },
+    )
+    try:
+        urllib.request.urlopen(req, timeout=_TIMEOUT_S).close()
+    except Exception:
+        pass  # best-effort; never let a dropped delivery affect the Hermes session
+
+
+def _emit(hook_event_name: str, session_id: str, **fields: Any) -> None:
+    if not session_id:
+        return
+    servers = _live_servers()
+    if not servers:
+        return
+    body = json.dumps({"hook_event_name": hook_event_name, "session_id": session_id, **fields}).encode(
+        "utf-8"
+    )
+    for server in servers:
+        _post(server, body)
+
+
+# ── Plugin hook handlers ──
+#
+# Signatures match the documented payload fields for each hook (see
+# ~/.hermes/hermes-agent/website/docs/user-guide/features/hooks.md, "Shipped
+# plugin-hook catalog"). All accept **_ for forward compatibility per Hermes's
+# "General rules for all hooks".
+
+
+def _on_session_start(session_id: str = "", model: str = "", platform: str = "", **_: Any) -> None:
+    _emit("SessionStart", session_id, cwd=os.getcwd())
+
+
+def _on_pre_tool_call(
+    tool_name: str = "",
+    args: Any = None,
+    tool_call_id: str = "",
+    session_id: str = "",
+    **_: Any,
+) -> None:
+    _emit(
+        "ExecStart",
+        session_id,
+        tool_id=tool_call_id or f"hermes-{tool_name}",
+        tool_name=tool_name,
+        tool_input=args,
+    )
+
+
+def _on_post_tool_call(tool_call_id: str = "", session_id: str = "", **_: Any) -> None:
+    _emit("ExecEnd", session_id, tool_id=tool_call_id or "current")
+
+
+def _on_session_end(
+    session_id: str = "",
+    completed: bool = True,
+    interrupted: bool = False,
+    **_: Any,
+) -> None:
+    # Hermes fires on_session_end at each TURN's finalization, not just process
+    # exit -- this is the per-turn "done / waiting for input" signal, normalized
+    # as turnEnd. Real process teardown is on_session_finalize (below).
+    _emit("TurnEnd", session_id, awaiting_input=bool(interrupted))
+
+
+def _on_session_finalize(session_id: str = "", reason: str = "", **_: Any) -> None:
+    _emit("SessionEnd", session_id, reason=reason or "finalize")
+
+
+def _on_subagent_start(
+    child_session_id: str = "",
+    parent_session_id: str = "",
+    child_role: str = "",
+    child_goal: str = "",
+    **_: Any,
+) -> None:
+    _emit(
+        "SubagentStart",
+        parent_session_id,
+        child_session_id=child_session_id,
+        agent_type=child_role or "subagent",
+        goal=child_goal,
+    )
+
+
+def _on_subagent_stop(parent_session_id: str = "", child_session_id: str = "", **_: Any) -> None:
+    _emit("SubagentStop", parent_session_id, child_session_id=child_session_id)
+
+
+def register(ctx: Any) -> None:
+    ctx.register_hook("on_session_start", _on_session_start)
+    ctx.register_hook("pre_tool_call", _on_pre_tool_call)
+    ctx.register_hook("post_tool_call", _on_post_tool_call)
+    ctx.register_hook("on_session_end", _on_session_end)
+    ctx.register_hook("on_session_finalize", _on_session_finalize)
+    ctx.register_hook("subagent_start", _on_subagent_start)
+    ctx.register_hook("subagent_stop", _on_subagent_stop)

--- a/server/src/providers/index.ts
+++ b/server/src/providers/index.ts
@@ -13,3 +13,5 @@
 
 export { claudeProvider } from './hook/claude/claude.js';
 export { copyHookScript } from './hook/claude/claudeHookInstaller.js';
+export { codexProvider } from './hook/codex/codex.js';
+export { hermesProvider } from './hook/hermes/hermes.js';


### PR DESCRIPTION
## Description

Adds two new `HookProvider` integrations — **Codex CLI** and **Hermes Agent** — on top of a small runtime patch that lets `AgentRuntime` host more than one provider at once (previously hardcoded to exactly one). All three providers now share one `AgentStateStore`/office; agents from any of them render side by side, independently tracked.

Both new integrations are built against each CLI's *actual* current capabilities, checked directly rather than assumed:

- **Codex CLI** (0.144.1) has no hooks/plugin API. It does write a structured, append-only JSONL rollout per session (`~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl` — `session_meta`, `response_item.function_call`/`function_call_output`, `event_msg.task_complete`). `codexTailer.ts` polls that directory (byte-offset tracked per file, partial-line-safe) and re-emits parsed events through the existing `POST /api/hooks/:providerId` ingress — reading Codex's own structured format, not scraping terminal output.
- **Hermes Agent** (v0.20.0) turns out to have three separate hook systems, and only one of them actually covers CLI sessions: gateway hooks fire only for messaging-platform sessions (Telegram/Discord/Slack/WhatsApp/Teams), shell hooks cover CLI but only a small fixed event set, and plugin hooks (`ctx.register_hook()` under `~/.hermes/plugins/`) carry the full documented lifecycle catalog this needed (`pre_tool_call`/`post_tool_call`/`on_session_start`/`on_session_end`/`on_session_finalize`/`subagent_start`/`subagent_stop`). `installHooks()` drops a small stdlib-only Python plugin there and enables it via the documented `hermes plugins enable` CLI — no new dependency in Hermes's venv, no hand-edited `config.yaml`.

### The runtime patch

`AgentRuntime`/`HookEventHandler` previously took one `provider: HookProvider` at construction. This PR changes the constructor to `providers: HookProvider[]` and builds one `HookEventHandler` per provider (each still scoped to exactly one provider internally — no shared mutable "current provider" field, so concurrent events from different providers can't race). All handlers share the runtime's `store`/timer Maps/`SessionRouter` seam. The module-level file-watcher/team singletons (`setHookProvider`, `setFileWatcherHookProvider`, `setTeamProvider`) stay bound to `providers[0]` (Claude) only, since neither new provider relies on the JSONL-scanning fallback path — this keeps Claude's existing behavior byte-for-byte identical (see Test plan).

## Type of change

- [x] New feature

## Test plan

- `npm run build && cd server && npx vitest run` → **419 passed** (377 pre-existing, unmodified, confirming Claude support has zero regressions + 42 new).
- New: `server/__tests__/codex.test.ts`, `server/__tests__/hermes.test.ts` — `normalizeHookEvent` per event, `formatToolStatus`, reading-vs-writing tool classification.
- New: `server/__tests__/agentRuntime.multiProvider.test.ts` — simultaneous sessions from different providers landing in one store tagged by `providerId`, duplicate-event handling, malformed/wrong-typed events never throwing, isolated tool state between concurrent agents on different providers, unknown-`providerId` events dropped safely, `dispose()` tearing down every provider handler.
- Manual: ran a real `codex exec` session against a temp dir and confirmed the full parse → normalize → route pipeline fired end-to-end over the actual JSONL rollout Codex wrote (confirmed via server logs); confirmed the untracked-project-dir privacy gate (the same one Claude uses) correctly declined to visually adopt it, proving the gate applies uniformly across providers.
- `npm run lint`, `npm run check-types`, `npm run asyncapi:generate` (no drift), `npm run e2e:inventory` (no drift) all pass clean.

## E2E coverage

- [ ] If user-visible behavior changed, an e2e test was added or updated under `pixel-agents/e2e/tests/`.
- [x] Explain below.

**What e2e tests cover this change?** No Playwright e2e was added. The existing suite's e2e model (`e2e/README.md` → "Mocking model & rules") is built around mocking a real `claude` binary via `mock-claude`/VS Code Electron fixtures — extending that pattern to two more real CLIs (`codex`, `hermes`) that don't have an equivalent lightweight mock harness felt like a separate, larger effort better scoped as its own follow-up rather than folded into this PR. The `agentRuntime.multiProvider.test.ts` Vitest suite exercises the same runtime code path (`handleHookEvent` → `HookEventHandler` → `AgentStateStore`) that a Playwright e2e test would ultimately assert against, just without the browser/webview layer — happy to add real e2e coverage as a follow-up if maintainers would rather have it in this PR before merge.

## Known limitations (documented inline in the code)

- Codex's JSONL rollout format has no explicit "session ended" record, so a session is heuristically closed after an idle timeout if the process doesn't clearly exit first.
- Hermes only loads plugins at process start (`HookRegistry.discover_and_load()`), so a Hermes session already running before the plugin is installed cannot retroactively receive events — this is a Hermes limitation, not something this PR works around by restarting sessions.
