### PR TITLE
feat(server): add Hermes HookProvider adapter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7140,7 +7140,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
       "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -11402,9 +11401,11 @@
         "@fastify/cors": "^11.2.0",
         "@fastify/static": "^10.1.2",
         "@fastify/websocket": "^11.2.0",
-        "fastify": "^5.8.5"
+        "fastify": "^5.8.5",
+        "js-yaml": "^4.1.0"
       },
       "devDependencies": {
+        "@types/js-yaml": "^4.0.9",
         "allure-vitest": "^3.9.0",
         "vitest": "^4.1.10"
       }
@@ -11448,6 +11449,13 @@
       "peerDependencies": {
         "eslint": ">=5.0.0"
       }
+    },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/server/__tests__/hermes.test.ts
+++ b/server/__tests__/hermes.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, it } from 'vitest';
+
+import { hermesProvider } from '../src/providers/hook/hermes/hermes.js';
+
+describe('hermesProvider', () => {
+  describe('identity', () => {
+    it('has kind "hook"', () => {
+      expect(hermesProvider.kind).toBe('hook');
+    });
+    it('has id "hermes"', () => {
+      expect(hermesProvider.id).toBe('hermes');
+    });
+    it('has a displayName', () => {
+      expect(hermesProvider.displayName).toBe('Hermes');
+    });
+    it('has delegate_task in subagentToolNames', () => {
+      expect(hermesProvider.subagentToolNames.has('delegate_task')).toBe(true);
+    });
+    it('has reading tools read_file/search_files/web_search/web_extract', () => {
+      for (const tool of ['read_file', 'search_files', 'web_search', 'web_extract']) {
+        expect(hermesProvider.readingTools.has(tool)).toBe(true);
+      }
+      expect(hermesProvider.readingTools.has('terminal')).toBe(false);
+      expect(hermesProvider.readingTools.has('patch')).toBe(false);
+    });
+    it('has protocolVersion 1', () => {
+      expect(hermesProvider.protocolVersion).toBe(1);
+    });
+    it('has a terminalNamePrefix', () => {
+      expect(hermesProvider.terminalNamePrefix).toBe('Hermes');
+    });
+    it('has no TeamProvider (Hermes subagents are plain delegate_task runs)', () => {
+      expect(hermesProvider.team).toBeUndefined();
+    });
+    it('has no file-fallback surface (Hermes sessions are SQLite, not JSONL)', () => {
+      expect(hermesProvider.getSessionDirs).toBeUndefined();
+      expect(hermesProvider.getAllSessionRoots).toBeUndefined();
+      expect(hermesProvider.sessionFilePattern).toBeUndefined();
+    });
+  });
+
+  describe('normalizeHookEvent', () => {
+    it('returns null when hook_event_name is missing', () => {
+      expect(hermesProvider.normalizeHookEvent({ session_id: 'x' })).toBeNull();
+    });
+    it('returns null when session_id is missing', () => {
+      expect(hermesProvider.normalizeHookEvent({ hook_event_name: 'pre_tool_call' })).toBeNull();
+    });
+    it('returns null for unknown hook event names', () => {
+      expect(
+        hermesProvider.normalizeHookEvent({
+          hook_event_name: 'SomethingWeird',
+          session_id: 'x',
+        }),
+      ).toBeNull();
+    });
+
+    it('normalizes pre_tool_call with tool_name + tool_input', () => {
+      const result = hermesProvider.normalizeHookEvent({
+        hook_event_name: 'pre_tool_call',
+        session_id: 'sess-1',
+        tool_name: 'read_file',
+        tool_input: { path: '/foo.ts' },
+        cwd: '/home/user/project',
+      });
+      expect(result?.sessionId).toBe('sess-1');
+      expect(result?.event.kind).toBe('toolStart');
+      if (result?.event.kind === 'toolStart') {
+        expect(result.event.toolName).toBe('read_file');
+        expect(result.event.toolId.startsWith('hook-')).toBe(true);
+        expect(result.event.input).toEqual({ path: '/foo.ts' });
+      }
+    });
+
+    it('pre_tool_call tolerates missing tool_input', () => {
+      const result = hermesProvider.normalizeHookEvent({
+        hook_event_name: 'pre_tool_call',
+        session_id: 'sess-1',
+        tool_name: 'terminal',
+      });
+      expect(result?.event.kind).toBe('toolStart');
+      if (result?.event.kind === 'toolStart') {
+        expect(result.event.input).toEqual({});
+      }
+    });
+
+    it('normalizes post_tool_call to toolEnd with sentinel toolId', () => {
+      const result = hermesProvider.normalizeHookEvent({
+        hook_event_name: 'post_tool_call',
+        session_id: 'sess-1',
+        tool_name: 'terminal',
+        extra: { status: 'ok', duration_ms: 42 },
+      });
+      expect(result?.event.kind).toBe('toolEnd');
+    });
+
+    it('normalizes on_turn_complete to turnEnd with awaitingInput=true', () => {
+      const result = hermesProvider.normalizeHookEvent({
+        hook_event_name: 'on_turn_complete',
+        session_id: 'sess-1',
+      });
+      expect(result?.event.kind).toBe('turnEnd');
+      if (result?.event.kind === 'turnEnd') {
+        expect(result.event.awaitingInput).toBe(true);
+      }
+    });
+
+    it('normalizes on_session_start with cwd and platform source', () => {
+      const result = hermesProvider.normalizeHookEvent({
+        hook_event_name: 'on_session_start',
+        session_id: 'sess-1',
+        cwd: '/Users/x/work',
+        extra: { model: 'deepseek-v4-flash', platform: 'cli' },
+      });
+      expect(result?.event.kind).toBe('sessionStart');
+      if (result?.event.kind === 'sessionStart') {
+        expect(result.event.source).toBe('cli');
+        expect(result.event.cwd).toBe('/Users/x/work');
+        expect(result.event.transcriptPath).toBeUndefined();
+      }
+    });
+
+    it('normalizes on_session_end with reason=completed from extra', () => {
+      const result = hermesProvider.normalizeHookEvent({
+        hook_event_name: 'on_session_end',
+        session_id: 'sess-1',
+        extra: { completed: true, interrupted: false, model: 'deepseek-v4-flash' },
+      });
+      expect(result?.event.kind).toBe('sessionEnd');
+      if (result?.event.kind === 'sessionEnd') {
+        expect(result.event.reason).toBe('completed');
+      }
+    });
+
+    it('normalizes on_session_end with reason=interrupted when interrupted', () => {
+      const result = hermesProvider.normalizeHookEvent({
+        hook_event_name: 'on_session_end',
+        session_id: 'sess-1',
+        extra: { completed: false, interrupted: true },
+      });
+      expect(result?.event.kind).toBe('sessionEnd');
+      if (result?.event.kind === 'sessionEnd') {
+        expect(result.event.reason).toBe('interrupted');
+      }
+    });
+
+    it('normalizes subagent_start with child_role as toolName', () => {
+      const result = hermesProvider.normalizeHookEvent({
+        hook_event_name: 'subagent_start',
+        session_id: 'sess-1',
+        extra: {
+          child_role: 'leaf',
+          child_session_id: 'sess-child',
+          child_goal: 'Review the diff',
+        },
+      });
+      expect(result?.event.kind).toBe('subagentStart');
+      if (result?.event.kind === 'subagentStart') {
+        expect(result.event.toolName).toBe('leaf');
+        expect(result.event.parentToolId).toBe('current');
+        expect(result.event.toolId.startsWith('hook-sub-leaf-')).toBe(true);
+      }
+    });
+
+    it('normalizes subagent_stop to subagentEnd', () => {
+      const result = hermesProvider.normalizeHookEvent({
+        hook_event_name: 'subagent_stop',
+        session_id: 'sess-1',
+        extra: { child_role: 'leaf', child_status: 'success' },
+      });
+      expect(result?.event.kind).toBe('subagentEnd');
+    });
+
+    it('drops gateway_platform_event (no AgentEvent shape fits)', () => {
+      expect(
+        hermesProvider.normalizeHookEvent({
+          hook_event_name: 'gateway_platform_event',
+          session_id: 'sess-1',
+          extra: { platform: 'telegram', event_type: 'reaction' },
+        }),
+      ).toBeNull();
+    });
+
+    it('drops on_session_finalize (sessionEnd already removes the agent)', () => {
+      expect(
+        hermesProvider.normalizeHookEvent({
+          hook_event_name: 'on_session_finalize',
+          session_id: 'sess-1',
+        }),
+      ).toBeNull();
+    });
+  });
+
+  describe('formatToolStatus', () => {
+    it('formats terminal with command', () => {
+      expect(hermesProvider.formatToolStatus('terminal', { command: 'npm test' })).toBe(
+        'Running: npm test',
+      );
+    });
+    it('formats read_file', () => {
+      expect(hermesProvider.formatToolStatus('read_file', { path: '/a/b.ts' })).toBe(
+        'Reading b.ts',
+      );
+    });
+    it('formats write_file', () => {
+      expect(hermesProvider.formatToolStatus('write_file', { path: '/a/c.ts' })).toBe(
+        'Writing c.ts',
+      );
+    });
+    it('formats patch with a single path', () => {
+      expect(hermesProvider.formatToolStatus('patch', { path: '/a/d.ts' })).toBe('Editing d.ts');
+    });
+    it('formats patch with a multi-file V4A path array', () => {
+      expect(hermesProvider.formatToolStatus('patch', { path: ['/a/one.ts', '/a/two.ts'] })).toBe(
+        'Editing one.ts, two.ts',
+      );
+    });
+    it('formats search_files / web_search / web_extract', () => {
+      expect(hermesProvider.formatToolStatus('search_files')).toBe('Searching files');
+      expect(hermesProvider.formatToolStatus('web_search')).toBe('Searching the web');
+      expect(hermesProvider.formatToolStatus('web_extract')).toBe('Extracting web content');
+    });
+    it('formats execute_code / browser_exec / computer_use', () => {
+      expect(hermesProvider.formatToolStatus('execute_code')).toBe('Running code');
+      expect(hermesProvider.formatToolStatus('browser_exec')).toBe('Browsing the web');
+      expect(hermesProvider.formatToolStatus('computer_use')).toBe('Controlling the computer');
+    });
+    it('formats delegate_task with goal', () => {
+      expect(hermesProvider.formatToolStatus('delegate_task', { goal: 'Research X' })).toBe(
+        'Subtask: Research X',
+      );
+      expect(hermesProvider.formatToolStatus('delegate_task')).toBe('Running subtask');
+    });
+    it('formats skill_view with name', () => {
+      expect(hermesProvider.formatToolStatus('skill_view', { name: 'github-pr-workflow' })).toBe(
+        'Loading skill: github-pr-workflow',
+      );
+    });
+    it('falls back to "Using X" for unknown tools', () => {
+      expect(hermesProvider.formatToolStatus('FancyTool', {})).toBe('Using FancyTool');
+    });
+    it('handles undefined input', () => {
+      expect(hermesProvider.formatToolStatus('read_file', undefined)).toBe('Reading ');
+    });
+  });
+
+  describe('contextWindowForModel', () => {
+    it('returns small window for flash/mini models', () => {
+      expect(hermesProvider.contextWindowForModel?.('deepseek-v4-flash')).toBe(128_000);
+      expect(hermesProvider.contextWindowForModel?.('gpt-4o-mini')).toBe(128_000);
+    });
+    it('returns large window for recognized large models', () => {
+      expect(hermesProvider.contextWindowForModel?.('claude-sonnet-5')).toBe(200_000);
+    });
+    it('returns undefined for unknown/synthetic models', () => {
+      expect(hermesProvider.contextWindowForModel?.('<synthetic>')).toBeUndefined();
+      expect(hermesProvider.contextWindowForModel?.(undefined)).toBeUndefined();
+    });
+  });
+});

--- a/server/__tests__/hermesHookAuth.test.ts
+++ b/server/__tests__/hermesHookAuth.test.ts
@@ -1,0 +1,143 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Use isolated temp HOME to avoid touching real ~/.pixel-agents/
+let tmpBase: string;
+
+vi.mock('os', async () => {
+  const actual = await vi.importActual<typeof import('os')>('os');
+  return { ...actual, homedir: () => tmpBase };
+});
+
+// Must import AFTER mock setup
+const { PixelAgentsServer } = await import('../src/server.js');
+
+/** Compute the Hermes X-Hermes-Signature-256 header for a raw body. */
+function hermesSignature(token: string, body: string): string {
+  const digest = crypto.createHmac('sha256', token).update(body, 'utf8').digest('hex');
+  return `sha256=${digest}`;
+}
+
+async function postWithSignature(
+  port: number,
+  token: string,
+  body: string,
+  providerId = 'hermes',
+): Promise<Response> {
+  return fetch(`http://127.0.0.1:${port}/api/hooks/${providerId}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Hermes-Signature-256': hermesSignature(token, body),
+    },
+    body,
+  });
+}
+
+describe('hook route Hermes signature auth', () => {
+  let server: InstanceType<typeof PixelAgentsServer>;
+  let port: number;
+  let token: string;
+
+  beforeEach(async () => {
+    tmpBase = fs.mkdtempSync(path.join(os.tmpdir(), 'pxl-hermes-auth-test-'));
+    server = new PixelAgentsServer();
+    const config = await server.start();
+    port = config.port;
+    token = config.token;
+  });
+
+  afterEach(() => {
+    server?.stop();
+    try {
+      fs.rmSync(tmpBase, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  it('accepts a valid X-Hermes-Signature-256 (no Bearer header)', async () => {
+    const body = JSON.stringify({ session_id: 'abc', hook_event_name: 'pre_tool_call' });
+    const res = await postWithSignature(port, token, body);
+    expect(res.status).toBe(200);
+  });
+
+  it('still accepts the existing Bearer token contract', async () => {
+    const body = JSON.stringify({ session_id: 'abc', hook_event_name: 'pre_tool_call' });
+    const res = await fetch(`http://127.0.0.1:${port}/api/hooks/hermes`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body,
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects a signature computed with the wrong secret', async () => {
+    const body = JSON.stringify({ session_id: 'abc', hook_event_name: 'pre_tool_call' });
+    const res = await postWithSignature(port, 'wrong-secret', body);
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects a tampered body (signature does not match the payload)', async () => {
+    const body = JSON.stringify({ session_id: 'abc', hook_event_name: 'pre_tool_call' });
+    const res = await fetch(`http://127.0.0.1:${port}/api/hooks/hermes`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Hermes-Signature-256': hermesSignature(token, body + ' '),
+      },
+      body,
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects malformed signature headers', async () => {
+    const body = JSON.stringify({ session_id: 'abc', hook_event_name: 'pre_tool_call' });
+    for (const header of ['not-a-signature', 'sha256=xyz', 'sha256=' + '0'.repeat(63)]) {
+      const res = await fetch(`http://127.0.0.1:${port}/api/hooks/hermes`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Hermes-Signature-256': header,
+        },
+        body,
+      });
+      expect(res.status).toBe(401);
+    }
+  });
+
+  it('rejects requests with no credentials at all', async () => {
+    const body = JSON.stringify({ session_id: 'abc', hook_event_name: 'pre_tool_call' });
+    const res = await fetch(`http://127.0.0.1:${port}/api/hooks/hermes`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body,
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('fires the hook callback for a signature-authenticated event', async () => {
+    const received: Array<{ providerId: string; event: Record<string, unknown> }> = [];
+    server.onHookEvent((providerId, event) => received.push({ providerId, event }));
+    const body = JSON.stringify({ session_id: 'sess-h1', hook_event_name: 'on_session_start' });
+    const res = await postWithSignature(port, token, body);
+    expect(res.status).toBe(200);
+    // Give the (synchronous) callback a beat to record.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(received).toHaveLength(1);
+    expect(received[0].providerId).toBe('hermes');
+    expect(received[0].event.hook_event_name).toBe('on_session_start');
+  });
+
+  it('still returns 400 for invalid JSON with a valid signature', async () => {
+    const badBody = 'not json {{{';
+    const res = await postWithSignature(port, token, badBody);
+    expect(res.status).toBe(400);
+  });
+});

--- a/server/__tests__/hermesHookInstaller.test.ts
+++ b/server/__tests__/hermesHookInstaller.test.ts
@@ -1,0 +1,194 @@
+import * as fs from 'fs';
+import * as yaml from 'js-yaml';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+let tmpBase: string;
+
+vi.mock('os', async () => {
+  const actual = await vi.importActual<typeof import('os')>('os');
+  return { ...actual, homedir: () => tmpBase };
+});
+
+const { areHooksInstalled, getHermesConfigPath, installHooks, makeHookTarget, uninstallHooks } =
+  await import('../src/providers/hook/hermes/hermesHookInstaller.js');
+
+const SERVER_URL = 'http://127.0.0.1:48231';
+const TOKEN = 'test-token-123';
+
+function readConfig(): Record<string, unknown> {
+  const p = getHermesConfigPath();
+  return yaml.load(fs.readFileSync(p, 'utf-8')) as Record<string, unknown>;
+}
+
+describe('hermesHookInstaller', () => {
+  beforeEach(() => {
+    tmpBase = fs.mkdtempSync(path.join(os.tmpdir(), 'pxl-hermes-hook-test-'));
+    process.env.HERMES_CONFIG = path.join(tmpBase, 'hermes', 'config.yaml');
+  });
+
+  afterEach(() => {
+    delete process.env.HERMES_CONFIG;
+    try {
+      fs.rmSync(tmpBase, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  // 1. installHooks adds an entry to hooks.outbound
+  it('installHooks adds an entry to hooks.outbound', () => {
+    installHooks(SERVER_URL, TOKEN);
+    const config = readConfig();
+    const hooks = config.hooks as Record<string, unknown[]>;
+    expect(Array.isArray(hooks.outbound)).toBe(true);
+    expect(hooks.outbound).toHaveLength(1);
+    const entry = hooks.outbound[0] as Record<string, unknown>;
+    expect(entry.url).toBe(`${SERVER_URL}/api/hooks/hermes`);
+    expect(entry.events).toEqual([
+      'pre_tool_call',
+      'post_tool_call',
+      'on_session_start',
+      'on_session_end',
+      'subagent_start',
+      'subagent_stop',
+    ]);
+    expect(entry.matcher).toBe('.*');
+    expect(entry.secret).toBe(TOKEN);
+    expect(entry.name).toBe('pixel-agents');
+  });
+
+  // 2. installHooks is idempotent
+  it('installHooks is idempotent', () => {
+    installHooks(SERVER_URL, TOKEN);
+    installHooks(SERVER_URL, TOKEN);
+    const config = readConfig();
+    const outbound = (config.hooks as Record<string, unknown[]>).outbound;
+    expect(outbound).toHaveLength(1);
+  });
+
+  // 3. areHooksInstalled returns true after install
+  it('areHooksInstalled returns true after install', () => {
+    installHooks(SERVER_URL, TOKEN);
+    expect(areHooksInstalled()).toBe(true);
+  });
+
+  // 4. areHooksInstalled returns false before install
+  it('areHooksInstalled returns false before install', () => {
+    expect(areHooksInstalled()).toBe(false);
+  });
+
+  // 5. uninstallHooks removes entries
+  it('uninstallHooks removes entries', () => {
+    installHooks(SERVER_URL, TOKEN);
+    expect(areHooksInstalled()).toBe(true);
+    uninstallHooks();
+    expect(areHooksInstalled()).toBe(false);
+  });
+
+  // 6. uninstallHooks cleans empty hooks object
+  it('uninstallHooks cleans empty hooks object', () => {
+    installHooks(SERVER_URL, TOKEN);
+    uninstallHooks();
+    const config = readConfig();
+    expect(config.hooks).toBeUndefined();
+  });
+
+  // 7. Handles missing config dir/file
+  it('handles missing config gracefully', () => {
+    expect(() => areHooksInstalled()).not.toThrow();
+    expect(areHooksInstalled()).toBe(false);
+  });
+
+  // 8. Handles malformed config.yaml
+  it('handles malformed config.yaml gracefully', () => {
+    fs.mkdirSync(path.dirname(getHermesConfigPath()), { recursive: true });
+    fs.writeFileSync(getHermesConfigPath(), '::: not yaml :::');
+    expect(() => areHooksInstalled()).not.toThrow();
+    expect(areHooksInstalled()).toBe(false);
+  });
+
+  // 9. Preserves unrelated config keys (the CRITICAL corruption pitfall)
+  it('preserves unrelated config keys when installing', () => {
+    fs.mkdirSync(path.dirname(getHermesConfigPath()), { recursive: true });
+    fs.writeFileSync(
+      getHermesConfigPath(),
+      [
+        'mcp_servers:',
+        '  pencil:',
+        '    command: "D:\\\\bin\\\\pen.exe"',
+        '    args: ["--app", "desktop"]',
+        '    env: {}',
+        'model: deepseek-v4-flash',
+        '',
+      ].join('\n'),
+    );
+    installHooks(SERVER_URL, TOKEN);
+    const config = readConfig();
+    expect(config.model).toBe('deepseek-v4-flash');
+    const pencil = (config.mcp_servers as Record<string, unknown>).pencil as Record<
+      string,
+      unknown
+    >;
+    expect(pencil.command).toBe('D:\\bin\\pen.exe');
+    expect((config.hooks as Record<string, unknown[]>).outbound).toHaveLength(1);
+  });
+
+  // 10. Preserves other users' outbound webhook entries
+  it('preserves other outbound webhook entries', () => {
+    fs.mkdirSync(path.dirname(getHermesConfigPath()), { recursive: true });
+    fs.writeFileSync(
+      getHermesConfigPath(),
+      [
+        'hooks:',
+        '  outbound:',
+        '    - url: https://ci.example.com/hermes-events',
+        '      events: [on_session_end]',
+        '      name: ci-notify',
+        '',
+      ].join('\n'),
+    );
+    installHooks(SERVER_URL, TOKEN);
+    const config = readConfig();
+    const outbound = (config.hooks as Record<string, unknown[]>).outbound;
+    expect(outbound).toHaveLength(2);
+    expect((outbound[0] as Record<string, unknown>).name).toBe('ci-notify');
+    expect((outbound[1] as Record<string, unknown>).name).toBe('pixel-agents');
+  });
+
+  // 11. uninstallHooks leaves other users' entries untouched
+  it('uninstallHooks leaves other outbound entries untouched', () => {
+    fs.mkdirSync(path.dirname(getHermesConfigPath()), { recursive: true });
+    fs.writeFileSync(
+      getHermesConfigPath(),
+      [
+        'hooks:',
+        '  outbound:',
+        '    - url: https://ci.example.com/hermes-events',
+        '      events: [on_session_end]',
+        '      name: ci-notify',
+        '',
+      ].join('\n'),
+    );
+    installHooks(SERVER_URL, TOKEN);
+    uninstallHooks();
+    const config = readConfig();
+    const outbound = (config.hooks as Record<string, unknown[]>).outbound;
+    expect(outbound).toHaveLength(1);
+    expect((outbound[0] as Record<string, unknown>).name).toBe('ci-notify');
+  });
+
+  // 12. makeHookTarget builds a url rooted at the server URL + provider path
+  it('makeHookTarget normalizes trailing slashes in serverUrl', () => {
+    const target = makeHookTarget('http://127.0.0.1:48231/', TOKEN) as Record<string, unknown>;
+    expect(target.url).toBe('http://127.0.0.1:48231/api/hooks/hermes');
+  });
+
+  // 13. getHermesConfigPath honors $HERMES_CONFIG over ~/.hermes/config.yaml
+  it('getHermesConfigPath prefers $HERMES_CONFIG', () => {
+    const fromEnv = path.join(tmpBase, 'custom', 'config.yaml');
+    process.env.HERMES_CONFIG = fromEnv;
+    expect(getHermesConfigPath()).toBe(fromEnv);
+  });
+});

--- a/server/package.json
+++ b/server/package.json
@@ -6,6 +6,7 @@
     "test:watch": "vitest"
   },
   "devDependencies": {
+    "@types/js-yaml": "^4.0.9",
     "allure-vitest": "^3.9.0",
     "vitest": "^4.1.10"
   },
@@ -13,6 +14,7 @@
     "@fastify/cors": "^11.2.0",
     "@fastify/static": "^10.1.2",
     "@fastify/websocket": "^11.2.0",
-    "fastify": "^5.8.5"
+    "fastify": "^5.8.5",
+    "js-yaml": "^4.1.0"
   }
 }

--- a/server/src/httpServer.ts
+++ b/server/src/httpServer.ts
@@ -62,6 +62,26 @@ export async function createHttpServer(options: HttpServerOptions): Promise<Http
     bodyLimit: MAX_HOOK_BODY_SIZE,
   });
 
+  // Parse JSON with the raw bytes preserved on request.rawBody so the hook
+  // route can verify Hermes' X-Hermes-Signature-256 HMAC, which is computed
+  // over the exact body bytes (GitHub-webhook style). Fastify does not keep
+  // the raw payload after parsing, so the parser stashes the buffer on the
+  // request before handing the parsed object downstream. The parse-error path
+  // mirrors Fastify's default JSON parser (statusCode 400).
+  app.addContentTypeParser('application/json', { parseAs: 'buffer' }, (request, body, done) => {
+    try {
+      // parseAs: 'buffer' guarantees a Buffer at runtime despite the wider
+      // parser callback type.
+      const raw = body as Buffer;
+      (request as FastifyRequest & { rawBody?: Buffer }).rawBody = raw;
+      done(null, JSON.parse(raw.toString('utf8')));
+    } catch (err) {
+      const error = err as Error & { statusCode?: number };
+      error.statusCode = 400;
+      done(error, undefined);
+    }
+  });
+
   await app.register(fastifyCors, { origin: true });
   await app.register(fastifyWebsocket);
 
@@ -111,7 +131,7 @@ function registerHookRoute(app: FastifyInstance, options: HttpServerOptions): vo
   }>(
     `${HOOK_API_PREFIX}/:providerId`,
     {
-      preHandler: bearerAuth(options.token),
+      preHandler: hookAuth(options.token),
       schema: {
         params: {
           type: 'object',
@@ -213,15 +233,52 @@ function registerWebSocketRoute(app: FastifyInstance, options: HttpServerOptions
 
 // ── Auth Helper ────────────────────────────────────────────────
 
-function bearerAuth(expectedToken: string) {
+/** Constant-time string equality, safe for untrusted-length inputs. */
+function safeEqual(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a);
+  const bBuf = Buffer.from(b);
+  return aBuf.length === bBuf.length && crypto.timingSafeEqual(aBuf, bBuf);
+}
+
+/** Constant-time buffer equality, safe for untrusted-length inputs. */
+function safeEqualBuf(a: Buffer, b: Buffer): boolean {
+  return a.length === b.length && crypto.timingSafeEqual(a, b);
+}
+
+/**
+ * Auth for POST /api/hooks/:providerId. Accepts either:
+ *
+ *  1. The existing Bearer contract: `Authorization: Bearer <token>` — used by
+ *     the bundled Claude hook script and WebSocket clients.
+ *  2. Hermes-style HMAC: `X-Hermes-Signature-256: sha256=<hex>` — Hermes
+ *     outbound webhooks sign the raw body with HMAC-SHA256 (GitHub-webhook
+ *     style, agent/outbound_webhooks.py) using the same token as the secret,
+ *     so the seam verifies it against request.rawBody. No Bearer header is
+ *     ever sent by Hermes.
+ *
+ * Either credential authenticates; both failures return 401.
+ */
+function hookAuth(expectedToken: string) {
   return async (request: FastifyRequest, reply: FastifyReply) => {
+    // 1. Bearer token
     const auth = request.headers.authorization ?? '';
-    const expected = `Bearer ${expectedToken}`;
-    const authBuf = Buffer.from(auth);
-    const expectedBuf = Buffer.from(expected);
-    if (authBuf.length !== expectedBuf.length || !crypto.timingSafeEqual(authBuf, expectedBuf)) {
-      reply.code(401).send('unauthorized');
+    if (safeEqual(auth, `Bearer ${expectedToken}`)) return;
+
+    // 2. Hermes HMAC signature over the raw body
+    const signature = request.headers['x-hermes-signature-256'];
+    const prefix = 'sha256=';
+    if (typeof signature === 'string' && signature.startsWith(prefix)) {
+      const hex = signature.slice(prefix.length);
+      if (/^[0-9a-f]{64}$/i.test(hex)) {
+        const raw = (request as FastifyRequest & { rawBody?: Buffer }).rawBody;
+        if (raw) {
+          const expectedSig = crypto.createHmac('sha256', expectedToken).update(raw).digest();
+          if (safeEqualBuf(Buffer.from(hex, 'hex'), expectedSig)) return;
+        }
+      }
     }
+
+    reply.code(401).send('unauthorized');
   };
 }
 

--- a/server/src/providers/hook/hermes/constants.ts
+++ b/server/src/providers/hook/hermes/constants.ts
@@ -1,0 +1,58 @@
+/**
+ * Hermes-specific constants. Kept separate from `server/src/constants.ts` so a
+ * future single-provider `server/` build doesn't accidentally depend on Hermes
+ * unless Hermes is the active provider.
+ *
+ * Adding another provider? Create its own `providers/<kind>/<name>/constants.ts`.
+ */
+
+/** Provider id used in the hook route path (`/api/hooks/hermes`). */
+export const HERMES_PROVIDER_ID = 'hermes';
+
+/**
+ * Hook events to register in Hermes `config.yaml` `hooks.outbound`.
+ *
+ * Hermes fires these as plugin hooks, so outbound webhooks (and thus the
+ * Pixel Agents server) receive them. Each maps to an AgentEvent in
+ * `normalizeHookEvent` (see hermes.ts).
+ *
+ * `on_turn_complete` is intentionally NOT installed: in current Hermes it is a
+ * context-engine observation method (agent/context_engine.py), not a
+ * plugin-manager hook event, so an outbound webhook entry for it would be
+ * rejected with a warning at registration. normalizeHookEvent still handles
+ * the name defensively in case a future Hermes fires it on the wire.
+ */
+export const HERMES_HOOK_EVENTS = [
+  'pre_tool_call',
+  'post_tool_call',
+  'on_session_start',
+  'on_session_end',
+  'subagent_start',
+  'subagent_stop',
+] as const;
+
+/** Terminal name prefix used when launching Hermes in a terminal.
+ *  Used by the extension to match terminals to agents for adoption. */
+export const HERMES_TERMINAL_NAME_PREFIX = 'Hermes';
+
+/**
+ * Marker name written into the `hooks.outbound` entry so install/uninstall and
+ * `areHooksInstalled` can identify Pixel Agents' own entry among other
+ * outbound webhooks the user may have configured (CI notifiers, dashboards, …).
+ */
+export const HERMES_HOOK_TARGET_NAME = 'pixel-agents';
+
+// ── Context windows (per model, in tokens) ──────────────────
+//
+// Hermes reports model ids from its provider config (model, provider) but
+// never the context limit, so these are best-effort denominators behind the
+// context gauge. Unknown ids return undefined and the runtime keeps its own
+// estimate (widening if a context ever exceeds it). The small-window regex is
+// deliberately conservative: guessing small for a large model pins every gauge
+// red, while the reverse is a quiet under-read the runtime corrects.
+/** Small/cheap model ids (flash/mini/nano/… variants). */
+export const HERMES_SMALL_CONTEXT_WINDOW = 128_000;
+/** Everything else we recognize runs the large window. */
+export const HERMES_LARGE_CONTEXT_WINDOW = 200_000;
+/** Model ids that run the small window. Everything else gets the large one. */
+export const HERMES_SMALL_CONTEXT_MODEL_PATTERN = /flash|mini|nano|tiny|small|haiku|lite\b/i;

--- a/server/src/providers/hook/hermes/hermes.ts
+++ b/server/src/providers/hook/hermes/hermes.ts
@@ -1,0 +1,247 @@
+import * as path from 'path';
+
+import type { AgentEvent, HookProvider } from '../../../../../core/src/provider.js';
+import {
+  BASH_COMMAND_DISPLAY_MAX_LENGTH,
+  TASK_DESCRIPTION_DISPLAY_MAX_LENGTH,
+} from '../../../constants.js';
+import {
+  HERMES_LARGE_CONTEXT_WINDOW,
+  HERMES_SMALL_CONTEXT_MODEL_PATTERN,
+  HERMES_SMALL_CONTEXT_WINDOW,
+  HERMES_TERMINAL_NAME_PREFIX,
+} from './constants.js';
+import {
+  areHooksInstalled as installerAreHooksInstalled,
+  installHooks as installerInstallHooks,
+  uninstallHooks as installerUninstallHooks,
+} from './hermesHookInstaller.js';
+
+// ── formatToolStatus ─────────────────────────────────────────
+//
+// Hermes tool names are snake_case (unlike Claude's PascalCase). The webview
+// renders read-like tools with the "reading" animation and everything else as
+// "typing", so classifying the read family here keeps the office character
+// legible without webview edits.
+
+const truncate = (s: string, max: number): string =>
+  s.length > max ? s.slice(0, max) + '\u2026' : s;
+
+export function formatToolStatus(toolName: string, input?: unknown): string {
+  const inp = (input ?? {}) as Record<string, unknown>;
+  const base = (p: unknown) => (typeof p === 'string' ? path.basename(p) : '');
+
+  switch (toolName) {
+    case 'terminal': {
+      const cmd = typeof inp.command === 'string' ? inp.command : '';
+      return `Running: ${truncate(cmd, BASH_COMMAND_DISPLAY_MAX_LENGTH)}`;
+    }
+    case 'read_file':
+      return `Reading ${base(inp.path)}`;
+    case 'write_file':
+      return `Writing ${base(inp.path)}`;
+    case 'patch': {
+      // patch accepts either a single path or a V4A multi-file patch whose
+      // `path` is an array of files.
+      const p = inp.path;
+      const names = Array.isArray(p) ? p.map(base).filter(Boolean) : [base(p)];
+      return `Editing ${names.join(', ')}`;
+    }
+    case 'search_files':
+      return 'Searching files';
+    case 'web_search':
+      return 'Searching the web';
+    case 'web_extract':
+      return 'Extracting web content';
+    case 'execute_code':
+      return 'Running code';
+    case 'browser_exec':
+      return 'Browsing the web';
+    case 'skill_view': {
+      const name = typeof inp.name === 'string' ? inp.name : '';
+      return name ? `Loading skill: ${name}` : 'Loading skill';
+    }
+    case 'computer_use':
+      return 'Controlling the computer';
+    case 'delegate_task': {
+      const goal = typeof inp.goal === 'string' ? inp.goal : '';
+      return goal
+        ? `Subtask: ${truncate(goal, TASK_DESCRIPTION_DISPLAY_MAX_LENGTH)}`
+        : 'Running subtask';
+    }
+    default:
+      return `Using ${toolName}`;
+  }
+}
+
+// ── normalizeHookEvent: the single Hermes-specific normalization boundary ──
+//
+// All raw Hermes outbound-webhook payload fields (hook_event_name,
+// tool_name, tool_input, session_id, cwd, extra) are read HERE and HERE ONLY.
+// Downstream (hookEventHandler.ts) sees only the normalized AgentEvent union.
+//
+// Hermes wire format (agent/outbound_webhooks.py) matches the Claude hook
+// payload shape, so the same sentinel conventions apply: 'current' toolIds for
+// PostToolUse/SubagentStop (the raw payload carries no id; the handler
+// correlates via its own currentHookToolId state) and synthetic hook-* ids for
+// tool starts.
+//
+// Event-name gaps (v2): Hermes has no permissionRequest event — approvals are
+// surfaced as an interactive CLI prompt, never a hook. A future permission
+// surface should map to the permissionRequest AgentEvent.
+
+function normalizeHookEvent(
+  raw: Record<string, unknown>,
+): { sessionId: string; event: AgentEvent } | null {
+  const eventName = raw.hook_event_name;
+  const sessionId = raw.session_id;
+  if (typeof eventName !== 'string' || typeof sessionId !== 'string') return null;
+
+  // Helper to read the `extra` bag that carries event-specific kwargs.
+  const extra = (): Record<string, unknown> =>
+    typeof raw.extra === 'object' && raw.extra !== null
+      ? (raw.extra as Record<string, unknown>)
+      : {};
+
+  switch (eventName) {
+    case 'pre_tool_call': {
+      const toolName = typeof raw.tool_name === 'string' ? raw.tool_name : '';
+      const toolInput =
+        typeof raw.tool_input === 'object' && raw.tool_input !== null
+          ? (raw.tool_input as Record<string, unknown>)
+          : {};
+      return {
+        sessionId,
+        event: {
+          kind: 'toolStart',
+          toolId: `hook-${Date.now()}`,
+          toolName,
+          input: toolInput,
+        },
+      };
+    }
+
+    case 'post_tool_call':
+      return { sessionId, event: { kind: 'toolEnd', toolId: 'current' } };
+
+    case 'on_turn_complete':
+      // Hermes finished its turn and is now idle waiting on the user.
+      return { sessionId, event: { kind: 'turnEnd', awaitingInput: true } };
+
+    case 'on_session_start': {
+      const e = extra();
+      return {
+        sessionId,
+        event: {
+          kind: 'sessionStart',
+          source: typeof e.platform === 'string' ? e.platform : undefined,
+          cwd: typeof raw.cwd === 'string' ? raw.cwd : undefined,
+        },
+      };
+    }
+
+    case 'on_session_end': {
+      const e = extra();
+      const reason =
+        e.interrupted === true ? 'interrupted' : e.completed === true ? 'completed' : undefined;
+      return { sessionId, event: { kind: 'sessionEnd', reason } };
+    }
+
+    case 'subagent_start': {
+      const e = extra();
+      const role = typeof e.child_role === 'string' ? e.child_role : 'unknown';
+      return {
+        sessionId,
+        event: {
+          kind: 'subagentStart',
+          parentToolId: 'current',
+          toolId: `hook-sub-${role}-${Date.now()}`,
+          toolName: role,
+          input: raw,
+        },
+      };
+    }
+
+    case 'subagent_stop':
+      return {
+        sessionId,
+        event: { kind: 'subagentEnd', parentToolId: 'current', toolId: 'current' },
+      };
+
+    // gateway_platform_event (Telegram/Discord reactions, edits, …) and
+    // on_session_finalize (session cleanup) are informational/duplicate for
+    // character lifecycle — on_session_end already removes the agent. Drop.
+    case 'gateway_platform_event':
+    case 'on_session_finalize':
+    default:
+      return null;
+  }
+}
+
+// ── Installer wrappers: adapt sync signatures to async interface ──
+
+function installHooks(serverUrl: string, authToken: string): Promise<void> {
+  installerInstallHooks(serverUrl, authToken);
+  return Promise.resolve();
+}
+
+function uninstallHooks(): Promise<void> {
+  installerUninstallHooks();
+  return Promise.resolve();
+}
+
+function areHooksInstalled(): Promise<boolean> {
+  return Promise.resolve(installerAreHooksInstalled());
+}
+
+// ── Context windows ──────────────────────────────────────────
+
+/**
+ * Window a Hermes model's context is measured against.
+ *
+ * Hermes reports the model id on every session-start payload but never the
+ * limit, so this table is a best-effort denominator for the context gauge.
+ * Unknown ids return undefined so the runtime keeps whatever it already
+ * assumed rather than adopting a fresh guess.
+ */
+export function contextWindowForModel(model: string | undefined): number | undefined {
+  if (!model || model === '<synthetic>') return undefined;
+  return HERMES_SMALL_CONTEXT_MODEL_PATTERN.test(model)
+    ? HERMES_SMALL_CONTEXT_WINDOW
+    : HERMES_LARGE_CONTEXT_WINDOW;
+}
+
+// ── The provider ──
+
+export const hermesProvider: HookProvider = {
+  kind: 'hook',
+  id: 'hermes',
+  displayName: 'Hermes',
+  protocolVersion: 1,
+
+  normalizeHookEvent,
+
+  installHooks,
+  uninstallHooks,
+  areHooksInstalled,
+
+  formatToolStatus,
+  permissionExemptTools: new Set(['delegate_task']),
+  subagentToolNames: new Set(['delegate_task']),
+  readingTools: new Set([
+    'read_file',
+    'search_files',
+    'web_search',
+    'web_extract',
+    'session_search',
+    'skill_view',
+  ]),
+  terminalNamePrefix: HERMES_TERMINAL_NAME_PREFIX,
+  contextWindowForModel,
+
+  // Intentionally omitted (Hermes sessions live in SQLite, not JSONL): the
+  // file-fallback surface (getSessionDirs / getAllSessionRoots /
+  // sessionFilePattern / parseTranscriptLine) and the TeamProvider. Hermes
+  // subagents are delegate_task runs, normalized as subagentStart/subagentEnd
+  // with no team semantics — no team handler is needed.
+};

--- a/server/src/providers/hook/hermes/hermesHookInstaller.ts
+++ b/server/src/providers/hook/hermes/hermesHookInstaller.ts
@@ -1,0 +1,154 @@
+import * as fs from 'fs';
+import * as yaml from 'js-yaml';
+import * as os from 'os';
+import * as path from 'path';
+
+import { HERMES_HOOK_EVENTS, HERMES_HOOK_TARGET_NAME, HERMES_PROVIDER_ID } from './constants.js';
+
+/**
+ * Install/uninstall Pixel Agents' Hermes outbound webhook in Hermes'
+ * `config.yaml` (`hooks.outbound` list).
+ *
+ * Hermes needs no hook script: it natively POSTs lifecycle events to
+ * configured outbound webhooks (agent/outbound_webhooks.py), and its wire
+ * format already matches the Claude-style payloads this server consumes
+ * (hook_event_name, tool_name, tool_input, session_id, cwd). The only thing
+ * the installer must do is append one target to `hooks.outbound` in
+ * `~/.hermes/config.yaml` (or `$HERMES_CONFIG`).
+ *
+ * CRITICAL: never edit list-valued config keys with `hermes config set` — it
+ * corrupts the loader (known Hermes issue). This installer always rewrites the
+ * YAML file directly with js-yaml, atomically via tmp + rename, mirroring the
+ * Claude settings.json installer.
+ */
+
+/** Hermes config location: $HERMES_CONFIG, else ~/.hermes/config.yaml. */
+export function getHermesConfigPath(): string {
+  const fromEnv = process.env.HERMES_CONFIG;
+  if (typeof fromEnv === 'string' && fromEnv.trim()) {
+    return fromEnv.trim();
+  }
+  return path.join(os.homedir(), '.hermes', 'config.yaml');
+}
+
+/** Read + parse Hermes config.yaml. Returns {} when missing or malformed. */
+export function readHermesConfig(): Record<string, unknown> {
+  const configPath = getHermesConfigPath();
+  try {
+    if (fs.existsSync(configPath)) {
+      const parsed = yaml.load(fs.readFileSync(configPath, 'utf-8'));
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    }
+  } catch (e) {
+    console.error(`[Pixel Agents] Failed to read Hermes config: ${e}`);
+  }
+  return {};
+}
+
+/** Write config back to ~/.hermes/config.yaml via atomic tmp + rename. */
+export function writeHermesConfig(config: Record<string, unknown>): void {
+  const configPath = getHermesConfigPath();
+  const dir = path.dirname(configPath);
+  try {
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+    const tmpPath = configPath + '.pixel-agents-tmp';
+    fs.writeFileSync(tmpPath, yaml.dump(config, { noRefs: true }), 'utf-8');
+    fs.renameSync(tmpPath, configPath);
+  } catch (e) {
+    console.error(`[Pixel Agents] Failed to write Hermes config: ${e}`);
+  }
+}
+
+/** True when the entry belongs to Pixel Agents (marker is the `name` field). */
+export function isOurHookEntry(entry: unknown): boolean {
+  return (
+    typeof entry === 'object' &&
+    entry !== null &&
+    (entry as Record<string, unknown>).name === HERMES_HOOK_TARGET_NAME
+  );
+}
+
+/**
+ * Build the `hooks.outbound` target entry for the Pixel Agents server.
+ *
+ * `authToken` is written inline as the signing secret so Hermes signs every
+ * delivery with `X-Hermes-Signature-256: sha256=<hex>` (GitHub-style HMAC),
+ * which the server's hook route accepts in place of a Bearer token. A
+ * `secret_env` pointing at an environment variable is the recommended
+ * alternative for non-local deployments, but an inline secret keeps a local
+ * 127.0.0.1 Pixel Agents server functional out of the box.
+ */
+export function makeHookTarget(serverUrl: string, authToken: string): Record<string, unknown> {
+  const base = serverUrl.replace(/\/+$/, '');
+  return {
+    url: `${base}/api/hooks/${HERMES_PROVIDER_ID}`,
+    events: [...HERMES_HOOK_EVENTS],
+    // Matcher is only honored for pre/post_tool_call; matches every tool.
+    matcher: '.*',
+    // Signs payloads (X-Hermes-Signature-256). Same value the server
+    // validates, so the hook route's Bearer-or-HMAC seam accepts these.
+    secret: authToken,
+    name: HERMES_HOOK_TARGET_NAME,
+  };
+}
+
+/** Check if the Pixel Agents Hermes outbound webhook is already installed. */
+export function areHooksInstalled(): boolean {
+  const config = readHermesConfig();
+  const hooks = config.hooks;
+  if (!hooks || typeof hooks !== 'object' || Array.isArray(hooks)) return false;
+  const outbound = (hooks as Record<string, unknown>).outbound;
+  return Array.isArray(outbound) && outbound.some(isOurHookEntry);
+}
+
+/**
+ * Append the Pixel Agents target to `hooks.outbound`. Idempotent: replaces any
+ * existing Pixel Agents entry with a fresh one (server URL/token may have
+ * changed since the last install) and preserves every other outbound target
+ * and every unrelated config key.
+ */
+export function installHooks(serverUrl: string, authToken: string): void {
+  const config = readHermesConfig();
+  const hooksRaw = config.hooks;
+  const hooks =
+    hooksRaw && typeof hooksRaw === 'object' && !Array.isArray(hooksRaw)
+      ? (hooksRaw as Record<string, unknown>)
+      : {};
+  const outbound = Array.isArray(hooks.outbound) ? hooks.outbound : [];
+  const filtered = outbound.filter((entry) => !isOurHookEntry(entry));
+  filtered.push(makeHookTarget(serverUrl, authToken));
+  hooks.outbound = filtered;
+  config.hooks = hooks;
+  writeHermesConfig(config);
+  console.log(`[Pixel Agents] Hermes hooks installed in ${getHermesConfigPath()}`);
+}
+
+/** Remove all Pixel Agents entries from hooks.outbound. Cleans up empty keys. */
+export function uninstallHooks(): void {
+  const config = readHermesConfig();
+  const hooksRaw = config.hooks;
+  if (!hooksRaw || typeof hooksRaw !== 'object' || Array.isArray(hooksRaw)) return;
+  const hooks = hooksRaw as Record<string, unknown>;
+  if (!Array.isArray(hooks.outbound)) return;
+
+  const filtered = hooks.outbound.filter((entry) => !isOurHookEntry(entry));
+  let changed = filtered.length !== hooks.outbound.length;
+  if (changed) {
+    if (filtered.length === 0) {
+      delete hooks.outbound;
+    } else {
+      hooks.outbound = filtered;
+    }
+    if (Object.keys(hooks).length === 0) {
+      delete config.hooks;
+    }
+    writeHermesConfig(config);
+  }
+  if (changed) {
+    console.log(`[Pixel Agents] Hermes hooks removed from ${getHermesConfigPath()}`);
+  }
+}

--- a/server/src/providers/index.ts
+++ b/server/src/providers/index.ts
@@ -13,3 +13,4 @@
 
 export { claudeProvider } from './hook/claude/claude.js';
 export { copyHookScript } from './hook/claude/claudeHookInstaller.js';
+export { hermesProvider } from './hook/hermes/hermes.js';


### PR DESCRIPTION
## Hermes HookProvider adapter

Adds a second `HookProvider` so Hermes roster bots render as characters in the Pixel Agents office, mirroring the reference Claude provider. Hermes needs **no code changes**: its config-driven outbound webhooks (`agent/outbound_webhooks.py`) already POST Claude-style payloads (`hook_event_name`, `tool_name`, `tool_input`, `session_id`, `cwd`), so the adapter is purely a normalization boundary on this side.

### What's included

**`server/src/providers/hook/hermes/hermes.ts`** — `HookProvider` impl:
- `normalizeHookEvent` mapping table:

  | Hermes event | AgentEvent |
  |---|---|
  | `pre_tool_call` | `toolStart` (synthetic `hook-*` toolId) |
  | `post_tool_call` | `toolEnd` (sentinel `current` toolId, correlated by the handler's `currentHookToolId`) |
  | `on_turn_complete` | `turnEnd` with `awaitingInput: true` (Hermes is idle waiting on the user) |
  | `on_session_start` | `sessionStart` (`source` from `extra.platform`, `cwd` top-level) |
  | `on_session_end` | `sessionEnd` (`reason` derived from `extra.completed`/`extra.interrupted`) |
  | `subagent_start` | `subagentStart` (`toolName` = `extra.child_role`) |
  | `subagent_stop` | `subagentEnd` |

  `gateway_platform_event` and `on_session_finalize` are intentionally dropped (informational / duplicate of `sessionEnd` cleanup).
- `formatToolStatus` for Hermes snake_case tools: `terminal`, `read_file`, `write_file`, `patch` (single + V4A multi-file path arrays), `search_files`, `web_search`, `web_extract`, `execute_code`, `browser_exec`, `computer_use`, `skill_view`, `delegate_task`.
- `subagentToolNames = {delegate_task}`, `readingTools` = read-family set, `permissionExemptTools = {delegate_task}`.
- `contextWindowForModel` — best-effort heuristic (small-window regex → 128k, else 200k, `undefined` for unknown/synthetic). Runtime widens on overrun, so a wrong guess self-corrects.
- **No `TeamProvider` and no file-fallback surface**: Hermes sessions live in SQLite, not JSONL, and subagents are plain `delegate_task` runs without team semantics.

**`hermesHookInstaller.ts`** — appends one target to `hooks.outbound` in Hermes `config.yaml` (`$HERMES_CONFIG` or `~/.hermes/config.yaml`):
- **Edits the YAML directly** with `js-yaml` (atomic tmp + rename), because `hermes config set` corrupts list-valued keys (known Hermes loader issue). Never uses it.
- Idempotent; preserves unrelated config keys and any other outbound webhook targets (marker: `name: pixel-agents`).
- Writes `secret: <server token>` so Hermes signs every delivery with `X-Hermes-Signature-256: sha256=<hex>` (GitHub-webhook style). `secret_env` is noted in-code as the recommended alternative for non-local deployments.
- Events installed: `pre_tool_call`, `post_tool_call`, `on_session_start`, `on_session_end`, `subagent_start`, `subagent_stop` (all valid `VALID_HOOKS` plugin events). See the caveat below about `on_turn_complete`.

**`httpServer.ts`** — the hook route now accepts **either** the existing `Authorization: Bearer <token>` **or** Hermes' `X-Hermes-Signature-256: sha256=<hex>` HMAC verified over the exact raw body bytes (preserved via a `parseAs: 'buffer'` JSON content-type parser). Constant-time comparisons on both paths.

**`providers/index.ts`** — exports `hermesProvider`.

### Known gaps (v2)

- **No `permissionRequest` event exists in Hermes.** Approvals are an interactive CLI prompt, never a hook. A future permission surface should map to the `permissionRequest` AgentEvent.
- **`on_turn_complete` is not a plugin-hook event today.** It's a context-engine observation method (`agent/context_engine.py`), so an outbound-webhook entry for it would be rejected at registration. `normalizeHookEvent` still handles the name defensively in case a future Hermes delivers it, but the installer's events list excludes it.

### Follow-ups (not in this PR)

- Provider *selection* wiring (which provider the standalone/VS Code server uses) — the provider is exported for adapters; the server currently hard-wires Claude.
- Installing gitleaks for the pre-commit hook on Windows dev machines (hook requires it).

## Verification

- `npm run check-types` — green (both `tsc --noEmit` passes).
- `npm run lint` — 0 errors (one pre-existing warning in `webview-ui/src/App.tsx`).
- `npm test`:
  - webview: 52/52 pass
  - package-contract: 7/7 pass
  - server: **425 pass, 10 fail — all 10 pre-existing on `main`** (verified by stashing this branch and running the same 3 files: identical failures). They are unrelated Windows test-infra issues:
    - `configPersistence.test.ts` / `clientMessageHandler.test.ts` (6): tests set `process.env.HOME` but `configPersistence.ts` resolves paths via `os.homedir()`, which on Windows ignores `HOME` — the tests read/write the **real** `~/.pixel-agents/config.json` instead of the temp dir.
    - `mockClaudeRunner.test.ts` (4): `fs.watch`-based tests time out (10s) on Windows.
  - New hermes tests: **58/58 pass** (`hermes.test.ts` normalize/format tables, `hermesHookInstaller.test.ts` install/idempotence/uninstall/preserve-keys, `hermesHookAuth.test.ts` HMAC-vs-Bearer auth).

## Dependency change

`server/package.json` gains `js-yaml` (+ `@types/js-yaml` dev) for YAML config editing. Lockfile diff is minimal (js-yaml was already in the tree as a transitive dep; its `dev` flag is flipped off since the server now depends on it at runtime).
