### PR TITLE
feat: add OpenCode as a second hook provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ It ships in two forms from the same codebase:
 - **VS Code extension** — [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=pablodelucca.pixel-agents) and [Open VSX](https://open-vsx.org/extension/pablodelucca/pixel-agents). Agents launch into VS Code terminals; characters render in the panel area.
 - **Standalone CLI** — `npx pixel-agents` starts a local server and serves the same office as a browser app, useful for tmux, remote, and non-VS Code workflows.
 
-The architecture is fully agent-agnostic and editor-agnostic: a typed `HookProvider` interface defines the integration boundary so adding a new AI tool is a single subdirectory of code. Claude Code is the reference implementation today; Codex, Gemini, Cursor, and others are on the roadmap.
+The architecture is fully agent-agnostic and editor-agnostic: a typed `HookProvider` interface defines the integration boundary so adding a new AI tool is a single subdirectory of code. Claude Code is the reference implementation, OpenCode ships as a second provider (see `docs/opencode-provider.md`); Codex, Gemini, Cursor, and others are on the roadmap.
 
 ![Pixel Agents screenshot](webview-ui/public/office.png)
 

--- a/adapters/vscode/PixelAgentsViewProvider.ts
+++ b/adapters/vscode/PixelAgentsViewProvider.ts
@@ -50,6 +50,8 @@ import {
   copyHookScript,
   hookProviderById,
   hookProviders,
+  installBridgePlugin,
+  opencodeProvider,
 } from '../../server/src/providers/index.js';
 import { PixelAgentsServer } from '../../server/src/server.js';
 import {
@@ -252,9 +254,17 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
   ): Promise<void> {
     // The bundled claude-hook.js script belongs to the Claude provider alone;
     // another provider's install must neither copy it nor be blocked by it.
+    // The OpenCode bridge plugin belongs to the OpenCode provider the same way.
     if (provider.id === claudeProvider.id && !copyHookScript(this.context.extensionPath)) {
       vscode.window.showErrorMessage(
         'Pixel Agents: could not install the hook script — hooks not installed.',
+      );
+      await this.reportHooksStatus(provider);
+      return;
+    }
+    if (provider.id === opencodeProvider.id && !installBridgePlugin(this.context.extensionPath)) {
+      vscode.window.showErrorMessage(
+        'Pixel Agents: could not install the OpenCode bridge plugin — hooks not installed.',
       );
       await this.reportHooksStatus(provider);
       return;
@@ -549,11 +559,13 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
         }
         // Provider capabilities: tool taxonomy for webview animation + subagent rendering.
         // Sent once before restoreAgents so characters render with correct animations
-        // from the first frame.
+        // from the first frame. Union over every registered provider (see
+        // clientMessageHandler.ts): tool names are provider-namespaced by case
+        // convention, so the union classifies correctly with no per-agent routing.
         this.webview?.postMessage({
           type: 'providerCapabilities',
-          readingTools: [...claudeProvider.readingTools],
-          subagentToolNames: [...claudeProvider.subagentToolNames],
+          readingTools: [...new Set(hookProviders.flatMap((p) => [...p.readingTools]))],
+          subagentToolNames: [...new Set(hookProviders.flatMap((p) => [...p.subagentToolNames]))],
         });
 
         // Settings + folder→Area mappings MUST be dispatched BEFORE restoreAgents

--- a/docs/adr/0002-per-event-provider-resolution.md
+++ b/docs/adr/0002-per-event-provider-resolution.md
@@ -1,0 +1,49 @@
+# Per-event provider resolution in the hook dispatch path
+
+`HookEventHandler` used to normalize every wire event through its constructor
+provider (Claude). With a second bundled provider (OpenCode), the event's own
+`providerId` — already threaded through `handleHookEvent`, the session
+router's buffer, and the HTTP route, but ignored — now resolves the provider
+per event, falling back to the constructor provider for unknown ids.
+
+Everything below is the rule for adding provider number three and beyond.
+
+## What resolves per event, and what stays on the constructor provider
+
+Per event (the resolved provider normalizes and displays the event in hand):
+
+- `normalizeHookEvent` — the normalization boundary stays per provider.
+- `formatToolStatus`, `subagentToolNames` — display and subagent routing.
+- `team` — teammate branches self-guard on its presence, so a teamless
+  provider takes the basic within-turn subagent path.
+
+Stays on the constructor provider (Claude):
+
+- File fallback (`getSessionDirs`, transcript parsing), terminal adoption
+  (`terminalNamePrefix`), and every module-level singleton (`setHookProvider`,
+  `setTeamProvider`). The OpenCode provider is hooks-only by construction:
+  OpenCode persists sessions in SQLite (`~/.local/share/opencode/opencode.db`),
+  not line-delimited transcripts, so there is no file fallback to implement.
+
+## Why the subagent gates changed shape, and why Claude cannot tell
+
+- `subagentStart` / `subagentEnd` used to require `provider.team` to reach
+  their handlers. They now always route; the teammate branch inside still
+  requires `provider.team`, and the basic path resolves the parent from JSONL
+  first. The only new behavior is the hook fallback: a normalized parent id
+  starting with `hook-` that equals the agent's live `currentHookToolId`.
+  Claude normalizes the `'current'` sentinel there, which never equals a real
+  id, so its routing is byte-for-byte identical.
+- The `Task`/`Agent` overlay suppression is now `provider.subagentToolNames`
+  instead of a name literal. Claude's set is exactly `{Task, Agent}`, so the
+  suppression is identical; transcript-less providers suppress nothing because
+  the hook display is their only display.
+- Turn end additionally purges subagent map entries keyed `hook-*`. JSONL
+  tool ids never carry that prefix, so JSONL-backed providers are unaffected.
+
+## Rejected alternative
+
+One `HookEventHandler` (and `AgentRuntime`) per provider: doubles every
+timer map, scanner, and store subscription, and splits one office across two
+state stores. The broadcast layer already multiplexes agents from any source;
+per-event resolution keeps that property.

--- a/docs/opencode-provider.md
+++ b/docs/opencode-provider.md
@@ -1,0 +1,70 @@
+# OpenCode provider
+
+OpenCode sessions appear in the office as hooks-only external agents — no
+transcript files involved. A small bridge plugin installed into OpenCode's
+global plugin directory reports bus events to the Pixel Agents server, and
+the OpenCode provider (`server/src/providers/hook/opencode/`) normalizes
+them into the shared `AgentEvent` model.
+
+## Files
+
+| Path                                                               | Role                                                                                                                                                                    |
+| ------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `server/src/providers/hook/opencode/opencode.ts`                   | `HookProvider` implementation: envelope normalization, tool status text, tool sets                                                                                      |
+| `server/src/providers/hook/opencode/bridge/pixel-agents-bridge.ts` | Self-contained OpenCode plugin (zero repo imports; runs under Bun). Maps bus events to hook envelopes and POSTs them to every live server in `~/.pixel-agents/servers/` |
+| `server/src/providers/hook/opencode/opencodeBridgeInstaller.ts`    | Install / uninstall / status. Owns exactly one file: `~/.config/opencode/plugins/pixel-agents.ts`                                                                       |
+| `server/src/providers/hook/opencode/constants.ts`                  | File names, marker, modes                                                                                                                                               |
+| `server/src/providers/hook/opencode/consentCopy.ts`                | First-run consent disclosure                                                                                                                                            |
+
+## Event mapping (bus event → envelope → AgentEvent)
+
+| OpenCode bus event                          | Envelope                                                        | AgentEvent                               |
+| ------------------------------------------- | --------------------------------------------------------------- | ---------------------------------------- |
+| `session.created`                           | `SessionStart` (+ `cwd` from `info.directory`)                  | `sessionStart`                           |
+| `session.deleted`                           | `SessionEnd` (reason `exit`)                                    | `sessionEnd`                             |
+| `session.idle`                              | `Stop`                                                          | `turnEnd` (Done)                         |
+| `tool.execute.before`                       | `PreToolUse` (`tool_name`, `tool_input`, `call_id`)             | `toolStart` (`hook-<callId>`)            |
+| `tool.execute.after`                        | `PostToolUse` / `PostToolUseFailure` (non-zero `metadata.exit`) | `toolEnd`                                |
+| `task` + `subagent_type`, before            | `SubagentStart` (type as `tool_name`)                           | `subagentStart` (parent `hook-<callId>`) |
+| `task` + `subagent_type`, after             | `SubagentStop`                                                  | `subagentEnd`                            |
+| `permission.asked` (alias `permission.ask`) | `PermissionRequest`                                             | `permissionRequest`                      |
+
+Tool names are OpenCode's lowercase ids (`read`, `edit`, `bash`, `task`,
+`skill`, …). Status text reuses the Claude prefixes (`Reading x.ts`,
+`Running: …`, `Subtask: …`) so character animations work with no webview
+change; the `providerCapabilities` broadcast carries the union of all
+registered providers' tool sets.
+
+## Install semantics
+
+- Identity is the marker comment, not the path: a same-named file without
+  the marker is the user's and install/uninstall refuse to touch it.
+- No backup: the installer only ever replaces a file carrying our own
+  marker, so there is no user content to preserve.
+- The bridge reads the server registry at event time (same protocol as
+  `claude-hook.js`: live `servers/*.json` entries, legacy `server.json`
+  fallback, dead-PID skip, 2 s best-effort POST). No server URL or token is
+  ever written into the plugin file.
+
+## Known limits (MVP)
+
+- No permission-timer heuristics and no context gauge denominator:
+  `contextWindowForModel` is unset (OpenCode spans many models/providers),
+  so the runtime keeps its estimate and widens on evidence.
+- Subagents render as basic sub-agent characters (no Agent Teams equivalent).
+- `session.deleted` always despawns; OpenCode has no `/clear`-style
+  session-handoff event to rebind.
+- Enabling works through the per-provider Settings toggle / consent ask.
+  The standalone startup auto-install block is still Claude-only.
+- No Playwright e2e spec yet — coverage is unit + installer + dispatch
+  tests plus manual-hook `.http` examples (`@provider = opencode`).
+
+## Manual test
+
+1. `npm run build`, then `node dist/cli.js --port 3100` from a workspace.
+2. Enable the OpenCode toggle in Settings (installs the bridge plugin), or
+   POST the envelopes in `server/manual-hook-events.http` (`@provider =
+opencode`) with `port`/`token` from `~/.pixel-agents/servers/`.
+3. Run an OpenCode session in the workspace: its character spawns on the
+   first tool call, animates per tool, bubbles on permission, and despawns
+   when the session is deleted.

--- a/esbuild.js
+++ b/esbuild.js
@@ -63,6 +63,32 @@ function buildHooks() {
 }
 
 /**
+ * Copy the OpenCode bridge plugin source verbatim to dist/bridge. No bundling:
+ * OpenCode loads the plugin directly with Bun, so the shipped file must stay a
+ * plain dependency-free TypeScript module (see bridge/pixel-agents-bridge.ts).
+ */
+function copyBridge() {
+  const src = path.join(
+    __dirname,
+    'server',
+    'src',
+    'providers',
+    'hook',
+    'opencode',
+    'bridge',
+    'pixel-agents-bridge.ts',
+  );
+  if (!fs.existsSync(src)) {
+    console.log('ℹ️  bridge source not found (optional)');
+    return;
+  }
+  const dstDir = path.join(__dirname, 'dist', 'bridge');
+  fs.mkdirSync(dstDir, { recursive: true });
+  fs.cpSync(src, path.join(dstDir, 'pixel-agents-bridge.ts'));
+  console.log('✓ Copied bridge/ → dist/bridge/');
+}
+
+/**
  * @type {import('esbuild').Plugin}
  */
 const esbuildProblemMatcherPlugin = {
@@ -108,6 +134,7 @@ async function main() {
     // Copy assets and hooks after build
     copyAssets();
     buildHooks();
+    copyBridge();
     await buildCli();
     await buildUninstall();
   }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "dist/cli.js",
     "dist/extension.js",
     "dist/hooks/claude-hook.js",
+    "dist/bridge/pixel-agents-bridge.ts",
     "dist/uninstall.js",
     "dist/assets/",
     "dist/webview/",

--- a/scripts/npm-package-contract.mjs
+++ b/scripts/npm-package-contract.mjs
@@ -20,6 +20,7 @@ export const REQUIRED_PACKAGE_FILES = [
   'dist/cli.js',
   'dist/extension.js',
   'dist/hooks/claude-hook.js',
+  'dist/bridge/pixel-agents-bridge.ts',
   'dist/webview/index.html',
   'icon.png',
   'package.json',

--- a/scripts/verify-vsix-package.mjs
+++ b/scripts/verify-vsix-package.mjs
@@ -13,6 +13,7 @@ const REQUIRED_FILES = [
   'extension/dist/extension.js',
   'extension/dist/cli.js',
   'extension/dist/hooks/claude-hook.js',
+  'extension/dist/bridge/pixel-agents-bridge.ts',
   'extension/dist/webview/index.html',
 ];
 const FORBIDDEN_PREFIXES = [

--- a/server/__tests__/consentFlow.test.ts
+++ b/server/__tests__/consentFlow.test.ts
@@ -102,7 +102,9 @@ describe('clientMessageHandler: hooks consent flow', () => {
     it('asks a privileged connection, carrying the provider disclosure verbatim', async () => {
       await connect();
 
-      const request = sent.find((m) => m.type === 'hooksConsentRequest');
+      const request = sent.find(
+        (m) => m.type === 'hooksConsentRequest' && m.providerId === 'claude',
+      );
       expect(request).toEqual({
         type: 'hooksConsentRequest',
         providerId: 'claude',
@@ -129,7 +131,11 @@ describe('clientMessageHandler: hooks consent flow', () => {
       grantHooksConsent('claude');
       await connect();
 
-      expect(sent.find((m) => m.type === 'hooksConsentRequest')).toBeUndefined();
+      // Per-provider: other registered providers with an open gate are still
+      // asked. This pins Claude's silence, not global silence.
+      expect(
+        sent.find((m) => m.type === 'hooksConsentRequest' && m.providerId === 'claude'),
+      ).toBeUndefined();
     });
 
     // The silent-grant population (a pre-consent version's install, migrated at
@@ -139,7 +145,9 @@ describe('clientMessageHandler: hooks consent flow', () => {
       seedInstalledHooks();
       await connect();
 
-      expect(sent.find((m) => m.type === 'hooksConsentRequest')).toBeUndefined();
+      expect(
+        sent.find((m) => m.type === 'hooksConsentRequest' && m.providerId === 'claude'),
+      ).toBeUndefined();
     });
 
     it('never asks while the hooks preference is off', async () => {
@@ -148,7 +156,9 @@ describe('clientMessageHandler: hooks consent flow', () => {
       setHooksEnabled('claude', false);
       await connect();
 
-      expect(sent.find((m) => m.type === 'hooksConsentRequest')).toBeUndefined();
+      expect(
+        sent.find((m) => m.type === 'hooksConsentRequest' && m.providerId === 'claude'),
+      ).toBeUndefined();
     });
 
     // Not-now writes nothing, so the gate must still be open on the next

--- a/server/__tests__/opencode.test.ts
+++ b/server/__tests__/opencode.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from 'vitest';
+
+import { opencodeProvider } from '../src/providers/hook/opencode/opencode.js';
+
+describe('opencodeProvider', () => {
+  describe('identity', () => {
+    it('has kind "hook"', () => {
+      expect(opencodeProvider.kind).toBe('hook');
+    });
+    it('has id "opencode"', () => {
+      expect(opencodeProvider.id).toBe('opencode');
+    });
+    it('has a displayName', () => {
+      expect(opencodeProvider.displayName).toBe('OpenCode');
+    });
+    it('has task in subagentToolNames', () => {
+      expect(opencodeProvider.subagentToolNames.has('task')).toBe(true);
+    });
+    it('has reading tools read/glob/grep/webfetch/websearch', () => {
+      for (const tool of ['read', 'glob', 'grep', 'webfetch', 'websearch']) {
+        expect(opencodeProvider.readingTools.has(tool)).toBe(true);
+      }
+      expect(opencodeProvider.readingTools.has('edit')).toBe(false);
+    });
+    it('has protocolVersion 1', () => {
+      expect(opencodeProvider.protocolVersion).toBe(1);
+    });
+    it('has no TeamProvider in the MVP', () => {
+      expect(opencodeProvider.team).toBeUndefined();
+    });
+    it('has no file fallback (OpenCode persists sessions in SQLite, not JSONL)', () => {
+      expect(opencodeProvider.getSessionDirs).toBeUndefined();
+      expect(opencodeProvider.getAllSessionRoots).toBeUndefined();
+      expect(opencodeProvider.sessionFilePattern).toBeUndefined();
+      expect(opencodeProvider.parseTranscriptLine).toBeUndefined();
+    });
+  });
+
+  describe('normalizeHookEvent', () => {
+    it('returns null when hook_event_name is missing', () => {
+      expect(opencodeProvider.normalizeHookEvent({ session_id: 'x' })).toBeNull();
+    });
+    it('returns null when session_id is missing', () => {
+      expect(opencodeProvider.normalizeHookEvent({ hook_event_name: 'Stop' })).toBeNull();
+    });
+    it('returns null for unknown hook event names', () => {
+      expect(
+        opencodeProvider.normalizeHookEvent({
+          hook_event_name: 'SomethingWeird',
+          session_id: 'x',
+        }),
+      ).toBeNull();
+    });
+
+    it('normalizes PreToolUse with tool_name + tool_input + stable call_id toolId', () => {
+      const result = opencodeProvider.normalizeHookEvent({
+        hook_event_name: 'PreToolUse',
+        session_id: 'ses-1',
+        tool_name: 'read',
+        tool_input: { path: '/foo.ts' },
+        call_id: 'call-9',
+      });
+      expect(result?.sessionId).toBe('ses-1');
+      expect(result?.event.kind).toBe('toolStart');
+      if (result?.event.kind === 'toolStart') {
+        expect(result.event.toolName).toBe('read');
+        expect(result.event.toolId).toBe('hook-call-9');
+        expect(result.event.input).toEqual({ path: '/foo.ts' });
+      }
+    });
+
+    it('PreToolUse without call_id falls back to a timestamp toolId', () => {
+      const result = opencodeProvider.normalizeHookEvent({
+        hook_event_name: 'PreToolUse',
+        session_id: 'ses-1',
+        tool_name: 'bash',
+        tool_input: {},
+      });
+      if (result?.event.kind === 'toolStart') {
+        expect(result.event.toolId.startsWith('hook-')).toBe(true);
+      } else {
+        expect.fail('expected toolStart');
+      }
+    });
+
+    it('normalizes PostToolUse and PostToolUseFailure to toolEnd with sentinel toolId', () => {
+      for (const name of ['PostToolUse', 'PostToolUseFailure']) {
+        const result = opencodeProvider.normalizeHookEvent({
+          hook_event_name: name,
+          session_id: 'ses-1',
+          call_id: 'call-9',
+        });
+        expect(result?.event.kind).toBe('toolEnd');
+      }
+    });
+
+    it('normalizes Stop to turnEnd without awaitingInput (Done, not waiting)', () => {
+      const result = opencodeProvider.normalizeHookEvent({
+        hook_event_name: 'Stop',
+        session_id: 'ses-1',
+      });
+      expect(result?.event.kind).toBe('turnEnd');
+      if (result?.event.kind === 'turnEnd') {
+        expect(result.event.awaitingInput).toBeFalsy();
+      }
+    });
+
+    it('normalizes SubagentStart with the subagent type as toolName', () => {
+      const result = opencodeProvider.normalizeHookEvent({
+        hook_event_name: 'SubagentStart',
+        session_id: 'ses-1',
+        tool_name: 'explore',
+        tool_input: { description: 'Explore auth' },
+        call_id: 'call-7',
+      });
+      expect(result?.event.kind).toBe('subagentStart');
+      if (result?.event.kind === 'subagentStart') {
+        expect(result.event.toolName).toBe('explore');
+        expect(result.event.toolId).toBe('hook-sub-explore-call-7');
+        expect(result.event.parentToolId).toBe('hook-call-7');
+      }
+    });
+
+    it('SubagentStart without call_id degrades to the current sentinel parent', () => {
+      const result = opencodeProvider.normalizeHookEvent({
+        hook_event_name: 'SubagentStart',
+        session_id: 'ses-1',
+        tool_name: 'explore',
+      });
+      if (result?.event.kind === 'subagentStart') {
+        expect(result.event.parentToolId).toBe('current');
+        expect(result.event.toolId.startsWith('hook-sub-explore-')).toBe(true);
+      } else {
+        expect.fail('expected subagentStart');
+      }
+    });
+
+    it('normalizes SubagentStop to subagentEnd', () => {
+      const result = opencodeProvider.normalizeHookEvent({
+        hook_event_name: 'SubagentStop',
+        session_id: 'ses-1',
+        call_id: 'call-7',
+      });
+      expect(result?.event.kind).toBe('subagentEnd');
+      if (result?.event.kind === 'subagentEnd') {
+        expect(result.event.parentToolId).toBe('hook-call-7');
+      }
+    });
+
+    it('normalizes PermissionRequest to permissionRequest', () => {
+      const result = opencodeProvider.normalizeHookEvent({
+        hook_event_name: 'PermissionRequest',
+        session_id: 'ses-1',
+      });
+      expect(result?.event.kind).toBe('permissionRequest');
+    });
+
+    it('normalizes SessionStart with source + cwd (no transcriptPath)', () => {
+      const result = opencodeProvider.normalizeHookEvent({
+        hook_event_name: 'SessionStart',
+        session_id: 'ses-1',
+        source: 'opencode',
+        cwd: '/Users/x/work',
+      });
+      expect(result?.event.kind).toBe('sessionStart');
+      if (result?.event.kind === 'sessionStart') {
+        expect(result.event.source).toBe('opencode');
+        expect(result.event.transcriptPath).toBeUndefined();
+        expect(result.event.cwd).toBe('/Users/x/work');
+      }
+    });
+
+    it('normalizes SessionEnd with reason', () => {
+      const result = opencodeProvider.normalizeHookEvent({
+        hook_event_name: 'SessionEnd',
+        session_id: 'ses-1',
+        reason: 'exit',
+      });
+      expect(result?.event.kind).toBe('sessionEnd');
+      if (result?.event.kind === 'sessionEnd') {
+        expect(result.event.reason).toBe('exit');
+      }
+    });
+  });
+
+  describe('formatToolStatus', () => {
+    it('formats read/edit/write with basenames', () => {
+      expect(opencodeProvider.formatToolStatus('read', { path: '/a/b.ts' })).toBe('Reading b.ts');
+      expect(opencodeProvider.formatToolStatus('edit', { filePath: '/a/b.ts' })).toBe(
+        'Editing b.ts',
+      );
+      expect(opencodeProvider.formatToolStatus('write', { filePath: '/a/b.ts' })).toBe(
+        'Writing b.ts',
+      );
+    });
+    it('formats bash with the command', () => {
+      expect(opencodeProvider.formatToolStatus('bash', { command: 'npm test' })).toBe(
+        'Running: npm test',
+      );
+    });
+    it('formats task with description', () => {
+      expect(opencodeProvider.formatToolStatus('task', { description: 'Code review' })).toBe(
+        'Subtask: Code review',
+      );
+    });
+    it('formats skill/question/todowrite', () => {
+      expect(opencodeProvider.formatToolStatus('skill', { name: 'tdd' })).toBe('Using skill tdd');
+      expect(opencodeProvider.formatToolStatus('question', {})).toBe('Waiting for your answer');
+      expect(opencodeProvider.formatToolStatus('todowrite', {})).toBe('Updating todos');
+    });
+    it('falls back to "Using X" for unknown tools', () => {
+      expect(opencodeProvider.formatToolStatus('fancy', {})).toBe('Using fancy');
+    });
+    it('handles undefined input', () => {
+      expect(opencodeProvider.formatToolStatus('read', undefined)).toBe('Reading ');
+    });
+  });
+
+  describe('consentDisclosure', () => {
+    it('returns a headline plus a three-paragraph disclosure', () => {
+      const { headline, disclosure } = opencodeProvider.consentDisclosure();
+      expect(headline.length).toBeGreaterThan(0);
+      expect(disclosure.split('\n\n')).toHaveLength(3);
+    });
+  });
+});

--- a/server/__tests__/opencodeBridgeInstaller.test.ts
+++ b/server/__tests__/opencodeBridgeInstaller.test.ts
@@ -1,0 +1,106 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+let tmpBase: string;
+let fakePackageRoot: string;
+
+vi.mock('os', async () => {
+  const actual = await vi.importActual<typeof import('os')>('os');
+  return { ...actual, homedir: () => tmpBase };
+});
+
+const {
+  areHooksInstalled,
+  installBridgePlugin,
+  installHooks,
+  uninstallHooks,
+  bridgeForeignFileMessage,
+} = await import('../src/providers/hook/opencode/opencodeBridgeInstaller.js');
+const { OPENCODE_PLUGIN_FILE_NAME, OPENCODE_PLUGIN_MARKER } =
+  await import('../src/providers/hook/opencode/constants.js');
+
+/** Real bridge source in the source tree, staged into the fake package root
+ *  the way the build stages it into dist/bridge/. */
+const REAL_BRIDGE_SOURCE = fileURLToPath(
+  new URL('../src/providers/hook/opencode/bridge/pixel-agents-bridge.ts', import.meta.url),
+);
+
+function pluginPathFor(): string {
+  return path.join(tmpBase, '.config', 'opencode', 'plugins', OPENCODE_PLUGIN_FILE_NAME);
+}
+
+function stageBridgeSource(): void {
+  const dst = path.join(fakePackageRoot, 'dist', 'bridge', 'pixel-agents-bridge.ts');
+  fs.mkdirSync(path.dirname(dst), { recursive: true });
+  fs.copyFileSync(REAL_BRIDGE_SOURCE, dst);
+}
+
+describe('opencodeBridgeInstaller', () => {
+  beforeEach(() => {
+    tmpBase = fs.mkdtempSync(path.join(os.tmpdir(), 'pxl-opencode-test-'));
+    fakePackageRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'pxl-opencode-pkg-'));
+    stageBridgeSource();
+  });
+
+  afterEach(() => {
+    for (const dir of [tmpBase, fakePackageRoot]) {
+      try {
+        fs.rmSync(dir, { recursive: true, force: true });
+      } catch {
+        /* ignore */
+      }
+    }
+  });
+
+  it('installBridgePlugin copies the bridge with the marker; installHooks resolves', async () => {
+    expect(areHooksInstalled()).toBe(false);
+    expect(installBridgePlugin(fakePackageRoot)).toBe(true);
+    const content = fs.readFileSync(pluginPathFor(), 'utf-8');
+    expect(content).toContain(OPENCODE_PLUGIN_MARKER);
+    expect(areHooksInstalled()).toBe(true);
+    await expect(installHooks()).resolves.toBeUndefined();
+  });
+
+  it('installBridgePlugin is idempotent', () => {
+    expect(installBridgePlugin(fakePackageRoot)).toBe(true);
+    const first = fs.readFileSync(pluginPathFor(), 'utf-8');
+    expect(installBridgePlugin(fakePackageRoot)).toBe(true);
+    expect(fs.readFileSync(pluginPathFor(), 'utf-8')).toBe(first);
+    expect(areHooksInstalled()).toBe(true);
+  });
+
+  it('refuses a foreign file at the destination and reports not installed', async () => {
+    const dst = pluginPathFor();
+    fs.mkdirSync(path.dirname(dst), { recursive: true });
+    fs.writeFileSync(dst, '// my own opencode plugin\nexport const Mine = async () => ({});\n');
+    expect(installBridgePlugin(fakePackageRoot)).toBe(false);
+    expect(fs.readFileSync(dst, 'utf-8')).toContain('my own opencode plugin');
+    expect(areHooksInstalled()).toBe(false);
+    await expect(installHooks()).rejects.toThrow();
+  });
+
+  it('returns false when the bridge source is missing', () => {
+    fs.rmSync(path.join(fakePackageRoot, 'dist'), { recursive: true, force: true });
+    expect(installBridgePlugin(fakePackageRoot)).toBe(false);
+    expect(areHooksInstalled()).toBe(false);
+  });
+
+  it('uninstallHooks removes our plugin and is a silent no-op when absent', async () => {
+    await expect(uninstallHooks()).resolves.toBeUndefined();
+    expect(installBridgePlugin(fakePackageRoot)).toBe(true);
+    await expect(uninstallHooks()).resolves.toBeUndefined();
+    expect(fs.existsSync(pluginPathFor())).toBe(false);
+    expect(areHooksInstalled()).toBe(false);
+  });
+
+  it('uninstallHooks refuses a foreign file', async () => {
+    const dst = pluginPathFor();
+    fs.mkdirSync(path.dirname(dst), { recursive: true });
+    fs.writeFileSync(dst, '// mine\n');
+    await expect(uninstallHooks()).rejects.toThrow(bridgeForeignFileMessage(dst));
+    expect(fs.readFileSync(dst, 'utf-8')).toBe('// mine\n');
+  });
+});

--- a/server/__tests__/opencodeHookDispatch.test.ts
+++ b/server/__tests__/opencodeHookDispatch.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { AgentStateStore } from '../src/agentStateStore.js';
+import { HookEventHandler } from '../src/hookEventHandler.js';
+import { claudeProvider } from '../src/providers/hook/claude/claude.js';
+import { hookProviderById } from '../src/providers/index.js';
+import { SessionRouter } from '../src/sessionRouter.js';
+import type { AgentState } from '../src/types.js';
+
+/** Minimal AgentState for testing (mirrors hookEventHandler.test.ts). */
+function createTestAgent(overrides: Partial<AgentState> = {}): AgentState {
+  return {
+    id: 1,
+    sessionId: '',
+    terminalRef: undefined,
+    isExternal: true,
+    projectDir: '/test',
+    jsonlFile: '',
+    fileOffset: 0,
+    lineBuffer: '',
+    activeToolIds: new Set(),
+    activeToolStatuses: new Map(),
+    activeToolNames: new Map(),
+    activeSubagentToolIds: new Map(),
+    activeSubagentToolNames: new Map(),
+    backgroundAgentToolIds: new Set(),
+    isWaiting: false,
+    permissionSent: false,
+    hadToolsInTurn: false,
+    lastDataAt: 0,
+    linesProcessed: 0,
+    seenUnknownRecordTypes: new Set(),
+    hookDelivered: false,
+    ...overrides,
+  } as AgentState;
+}
+
+describe('HookEventHandler multi-provider dispatch', () => {
+  let agents: AgentStateStore;
+  let waitingTimers: Map<number, ReturnType<typeof setTimeout>>;
+  let permissionTimers: Map<number, ReturnType<typeof setTimeout>>;
+  let messages: Array<Record<string, unknown>>;
+  let handler: HookEventHandler;
+
+  beforeEach(() => {
+    agents = new AgentStateStore();
+    waitingTimers = new Map();
+    permissionTimers = new Map();
+    messages = [];
+    agents.on('broadcast', (msg) => {
+      messages.push(msg as Record<string, unknown>);
+    });
+    // Same resolver wiring as AgentRuntime: constructor provider is Claude,
+    // per-event resolution goes through the registry.
+    handler = new HookEventHandler(
+      agents,
+      waitingTimers,
+      permissionTimers,
+      claudeProvider,
+      new SessionRouter(),
+      undefined,
+      (id: string) => hookProviderById(id),
+    );
+    agents.set(1, createTestAgent({ id: 1 }));
+    handler.registerAgent('ses-1', 1);
+  });
+
+  it('normalizes opencode events through the opencode provider', () => {
+    handler.handleEvent('opencode', {
+      hook_event_name: 'PreToolUse',
+      session_id: 'ses-1',
+      tool_name: 'read',
+      tool_input: { path: '/a/b.ts' },
+      call_id: 'call-1',
+    });
+    const start = messages.find((m) => m.type === 'agentToolStart');
+    expect(start).toMatchObject({ id: 1, toolName: 'read', status: 'Reading b.ts' });
+  });
+
+  it('falls back to the constructor provider for unknown ids', () => {
+    handler.handleEvent('nope', {
+      hook_event_name: 'PermissionRequest',
+      session_id: 'ses-1',
+    });
+    expect(messages.find((m) => m.type === 'agentToolPermission')).toBeTruthy();
+  });
+
+  it('routes opencode PermissionRequest to the permission bubble', () => {
+    handler.handleEvent('opencode', {
+      hook_event_name: 'PermissionRequest',
+      session_id: 'ses-1',
+    });
+    const msg = messages.find((m) => m.type === 'agentToolPermission');
+    expect(msg).toBeTruthy();
+    expect(msg?.id).toBe(1);
+  });
+
+  it('creates and clears a basic sub-agent character from hook-parented events', () => {
+    handler.handleEvent('opencode', {
+      hook_event_name: 'PreToolUse',
+      session_id: 'ses-1',
+      tool_name: 'task',
+      tool_input: { description: 'Explore auth' },
+      call_id: 'call-7',
+    });
+    // task is a subagent-spawning tool: no transient overlay of its own.
+    expect(messages.find((m) => m.type === 'agentToolStart')).toBeFalsy();
+
+    handler.handleEvent('opencode', {
+      hook_event_name: 'SubagentStart',
+      session_id: 'ses-1',
+      tool_name: 'explore',
+      tool_input: { description: 'Explore auth' },
+      call_id: 'call-7',
+    });
+    const start = messages.find((m) => m.type === 'subagentToolStart');
+    expect(start).toMatchObject({
+      id: 1,
+      parentToolId: 'hook-call-7',
+      toolId: 'hook-sub-explore-call-7',
+      status: 'Subtask: explore',
+    });
+
+    handler.handleEvent('opencode', {
+      hook_event_name: 'SubagentStop',
+      session_id: 'ses-1',
+      call_id: 'call-7',
+    });
+    const clear = messages.find((m) => m.type === 'subagentClear');
+    expect(clear).toMatchObject({ id: 1, parentToolId: 'hook-call-7' });
+  });
+
+  it('purges hook-parented subagents on turn end', () => {
+    handler.handleEvent('opencode', {
+      hook_event_name: 'PreToolUse',
+      session_id: 'ses-1',
+      tool_name: 'task',
+      tool_input: {},
+      call_id: 'call-8',
+    });
+    handler.handleEvent('opencode', {
+      hook_event_name: 'SubagentStart',
+      session_id: 'ses-1',
+      tool_name: 'explore',
+      tool_input: {},
+      call_id: 'call-8',
+    });
+    expect(messages.find((m) => m.type === 'subagentToolStart')).toBeTruthy();
+
+    handler.handleEvent('opencode', { hook_event_name: 'Stop', session_id: 'ses-1' });
+    const clear = messages.find((m) => m.type === 'subagentClear');
+    expect(clear).toMatchObject({ id: 1, parentToolId: 'hook-call-8' });
+    const statuses = messages.filter((m) => m.type === 'agentStatus');
+    expect(statuses.at(-1)).toMatchObject({ id: 1, status: 'waiting' });
+  });
+
+  it('keeps Claude subagent routing on the JSONL path (no hook fallback)', () => {
+    // A Claude SubagentStart with no JSONL parent and the 'current' sentinel
+    // parent must not create a character: JSONL handles it via agent_progress.
+    handler.handleEvent('claude', {
+      hook_event_name: 'SubagentStart',
+      session_id: 'ses-1',
+      agent_type: 'explore',
+    });
+    expect(messages.find((m) => m.type === 'subagentToolStart')).toBeFalsy();
+  });
+});

--- a/server/manual-hook-events.http
+++ b/server/manual-hook-events.http
@@ -113,6 +113,61 @@ Content-Type: application/json
 }
 
 ###
+# ── OpenCode provider ─────────────────────────────────────────────
+# Same route, @provider = opencode. Envelopes below are what the bridge plugin
+# (server/src/providers/hook/opencode/bridge/pixel-agents-bridge.ts) POSTs for
+# each OpenCode bus event. Tool names are OpenCode's lowercase ids; call_id
+# becomes the stable hook tool id (no Date.now() minting needed).
+# Set @provider = opencode and re-run the SessionStart → PreToolUse →
+# PermissionRequest → PostToolUse → Stop → SessionEnd sequence above with these
+# bodies to drive an OpenCode character end to end.
+
+###
+# OpenCode: stage a session (bridge maps session.created)
+POST http://{{host}}:{{port}}/api/hooks/opencode
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+{
+  "session_id": "{{sessionId}}",
+  "hook_event_name": "SessionStart",
+  "source": "opencode",
+  "cwd": "{{cwd}}"
+}
+
+###
+# OpenCode: tool start with stable call_id (bridge maps tool.execute.before)
+POST http://{{host}}:{{port}}/api/hooks/opencode
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+{
+  "session_id": "{{sessionId}}",
+  "hook_event_name": "PreToolUse",
+  "tool_name": "read",
+  "tool_input": {
+    "path": "src/index.ts"
+  },
+  "call_id": "call-1"
+}
+
+###
+# OpenCode: subagent spawn (bridge maps task calls carrying subagent_type)
+POST http://{{host}}:{{port}}/api/hooks/opencode
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+{
+  "session_id": "{{sessionId}}",
+  "hook_event_name": "SubagentStart",
+  "tool_name": "explore",
+  "tool_input": {
+    "description": "Explore auth flow"
+  },
+  "call_id": "call-2"
+}
+
+###
 # Optional: simulate `/clear` or `--resume` handoff
 # Run this after the original session exists. Then run the next request to rebind it.
 POST http://{{host}}:{{port}}/api/hooks/{{provider}}

--- a/server/src/agentRuntime.ts
+++ b/server/src/agentRuntime.ts
@@ -38,6 +38,7 @@ import type { HookEvent } from './hookEventHandler.js';
 import { HookEventHandler } from './hookEventHandler.js';
 import { assignPaletteIfNeeded } from './paletteAssigner.js';
 import { PathSet, pathsMatch } from './pathKey.js';
+import { hookProviderById } from './providers/index.js';
 import { SessionRouter } from './sessionRouter.js';
 import { SubagentWatch } from './subagentWatch.js';
 import { cancelPermissionTimer, cancelWaitingTimer } from './timerManager.js';
@@ -149,6 +150,11 @@ export class AgentRuntime {
       provider,
       new SessionRouter(),
       this.watchAllSessions,
+      // Per-event provider resolution: the constructor provider stays the
+      // default for file fallback and terminal adoption, while each wire
+      // event normalizes through the provider its id names. Unknown ids fall
+      // back to the constructor provider, exactly as before.
+      (providerId: string) => hookProviderById(providerId),
     );
 
     // Wire hook lifecycle callbacks to shared agent operations

--- a/server/src/cli.ts
+++ b/server/src/cli.ts
@@ -27,7 +27,13 @@ import {
 } from './configPersistence.js';
 import { MAX_PORT, MIN_PORT } from './constants.js';
 import { FileStateAdapter } from './fileStateAdapter.js';
-import { claudeProvider, copyHookScript, hookProviderById } from './providers/index.js';
+import {
+  claudeProvider,
+  copyHookScript,
+  hookProviderById,
+  installBridgePlugin,
+  opencodeProvider,
+} from './providers/index.js';
 import { PixelAgentsServer } from './server.js';
 
 // ── Argument parsing ──────────────────────────────────────────
@@ -101,6 +107,19 @@ function copyHookScriptOrReport(packageRoot: string, context = ''): boolean {
   return false;
 }
 
+/**
+ * Copy the OpenCode bridge plugin into ~/.config/opencode/plugins/, reporting failure.
+ *
+ * Same contract as copyHookScriptOrReport above: callers run this BEFORE the
+ * provider install and abort when it returns false, so a success report can
+ * never cover a missing plugin file.
+ */
+function installBridgePluginOrReport(packageRoot: string, context = ''): boolean {
+  if (installBridgePlugin(packageRoot)) return true;
+  console.error(`[Pixel Agents] Hooks NOT installed${context}: bridge plugin missing.`);
+  return false;
+}
+
 // ── Main ──────────────────────────────────────────────────────
 
 async function main(): Promise<void> {
@@ -162,11 +181,18 @@ async function main(): Promise<void> {
         // An explicit toggle in the UI IS the consent to modify the
         // provider's settings file. The bundled claude-hook.js script belongs
         // to the Claude provider alone; another provider's install must
-        // neither copy it nor be blocked by it.
+        // neither copy it nor be blocked by it. The OpenCode bridge plugin
+        // belongs to the OpenCode provider the same way.
         grantHooksConsent(provider.id);
         if (
           provider.id === claudeProvider.id &&
           !copyHookScriptOrReport(packageRoot, ' (user toggle)')
+        ) {
+          return;
+        }
+        if (
+          provider.id === opencodeProvider.id &&
+          !installBridgePluginOrReport(packageRoot, ' (user toggle)')
         ) {
           return;
         }

--- a/server/src/clientMessageHandler.ts
+++ b/server/src/clientMessageHandler.ts
@@ -359,11 +359,14 @@ function handleWebviewReady(send: WsSend, ctx: ClientMessageContext): void {
   const { store, runtime, cache } = ctx;
   const adapter = store.getAdapter();
 
-  // 1. Provider capabilities (must arrive before any agent messages)
+  // 1. Provider capabilities (must arrive before any agent messages).
+  // Union over every registered provider: tool names are provider-namespaced
+  // by case convention (Claude PascalCase, OpenCode lowercase), so the union
+  // classifies each event's tools correctly with no per-agent routing.
   send({
     type: 'providerCapabilities',
-    readingTools: [...claudeProvider.readingTools],
-    subagentToolNames: [...claudeProvider.subagentToolNames],
+    readingTools: [...new Set(hookProviders.flatMap((p) => [...p.readingTools]))],
+    subagentToolNames: [...new Set(hookProviders.flatMap((p) => [...p.subagentToolNames]))],
   });
 
   // 2. Assets (from server cache, loaded at startup via pngjs)

--- a/server/src/hookEventHandler.ts
+++ b/server/src/hookEventHandler.ts
@@ -69,6 +69,15 @@ export class HookEventHandler {
     private provider: HookProvider,
     private sessionRouter: SessionRouter,
     private watchAllSessionsRef?: { current: boolean },
+    /**
+     * Resolve the provider for an incoming wire event. The constructor
+     * provider stays the default (file fallback, terminal adoption, and every
+     * module-level singleton keep following it); per-event resolution only
+     * affects normalization and display of the event being dispatched. Hosts
+     * that serve a single provider omit this and every event resolves to the
+     * constructor provider, exactly as before.
+     */
+    private resolveProvider?: (providerId: string) => HookProvider | undefined,
   ) {
     if (provider.protocolVersion !== HookEventHandler.SUPPORTED_PROTOCOL_VERSION) {
       console.warn(
@@ -79,16 +88,23 @@ export class HookEventHandler {
     }
   }
 
+  /** Provider for one wire event: the registry hit, or the constructor
+   *  provider when the id names nothing registered (fail-open to the
+   *  long-standing default, never to a drop). */
+  private providerFor(providerId: string): HookProvider {
+    return this.resolveProvider?.(providerId) ?? this.provider;
+  }
+
   /** Merged set of tool names that spawn subagents (teammates + within-turn subagents
    *  when a team provider is attached, or the base HookProvider set otherwise). */
-  private getSubagentToolSet(): ReadonlySet<string> {
-    if (this.provider.team) {
+  private getSubagentToolSet(provider: HookProvider): ReadonlySet<string> {
+    if (provider.team) {
       return new Set<string>([
-        ...this.provider.team.teammateSpawnTools,
-        ...this.provider.team.withinTurnSubagentTools,
+        ...provider.team.teammateSpawnTools,
+        ...provider.team.withinTurnSubagentTools,
       ]);
     }
-    return this.provider.subagentToolNames;
+    return provider.subagentToolNames;
   }
 
   /** Check if a session is tracked (in workspace project dir, or Watch All Sessions ON). */
@@ -129,18 +145,19 @@ export class HookEventHandler {
    * @param providerId - Provider that sent the event ('claude', 'codex', etc.)
    * @param event - The hook event payload from the CLI tool
    */
-  handleEvent(_providerId: string, event: HookEvent): void {
-    if (this.provider.protocolVersion !== HookEventHandler.SUPPORTED_PROTOCOL_VERSION) {
+  handleEvent(providerId: string, event: HookEvent): void {
+    const provider = this.providerFor(providerId);
+    if (provider.protocolVersion !== HookEventHandler.SUPPORTED_PROTOCOL_VERSION) {
       return; // version mismatch already logged in constructor
     }
     // ── Provider normalization boundary ───────────────────────────────────────
-    // All raw Claude-specific fields (tool_name, tool_input, agent_type, teammate_name,
+    // All raw provider-specific fields (tool_name, tool_input, agent_type, teammate_name,
     // task_subject, notification_type,
     // reason, source) are extracted by provider.normalizeHookEvent. Downstream dispatch
     // uses the normalized AgentEvent.kind. Raw `event.*` reads are still allowed in a few
     // places for provider-specific metadata that AgentEvent doesn't capture (transcript_path,
     // cwd for external-session adoption; event-specific teammate identity for routing).
-    const normalized = this.provider.normalizeHookEvent(event);
+    const normalized = provider.normalizeHookEvent(event);
     if (!normalized) return; // unknown / uninteresting event -- silently drop
     const normEvent = normalized.event;
     const eventName = event.hook_event_name; // retained for logs only
@@ -277,7 +294,7 @@ export class HookEventHandler {
         pending.cwd,
       );
       // Re-process this event now that the agent exists
-      this.handleEvent(_providerId, event);
+      this.handleEvent(providerId, event);
       return;
     }
 
@@ -307,7 +324,7 @@ export class HookEventHandler {
           console.log(
             `[Pixel Agents] Hook: ${eventName} - unknown session ${event.session_id.slice(0, 8)}..., buffering`,
           );
-        this.sessionRouter.bufferEvent(_providerId, event);
+        this.sessionRouter.bufferEvent(providerId, event);
       }
       return;
     }
@@ -326,18 +343,20 @@ export class HookEventHandler {
     // retain their raw payload for the team-routing handler's identity extraction.
     switch (normEvent.kind) {
       case 'sessionEnd':
-        return this.handleSessionEnd(normEvent, agent, agentId);
+        return this.handleSessionEnd(normEvent, agent, agentId, provider);
       case 'toolStart':
-        return this.handlePreToolUse(normEvent, agent, agentId);
+        return this.handlePreToolUse(normEvent, agent, agentId, provider);
       case 'toolEnd':
         // Both PostToolUse and PostToolUseFailure normalize to toolEnd. Distinguishing
         // them inside handlers would require extra info; the existing behavior was
         // identical for both (agentToolDone + clear currentHookToolId), so one branch suffices.
         return this.handlePostToolUse(agent, agentId);
       case 'subagentStart':
-        return this.provider.team ? this.handleSubagentStart(event, agent, agentId) : undefined;
+        // Teamless providers (OpenCode) take the basic within-turn path inside
+        // handleSubagentStart; the teammate branch self-guards on provider.team.
+        return this.handleSubagentStart(event, agent, agentId, provider, normEvent);
       case 'subagentEnd':
-        return this.provider.team ? this.handleSubagentStop(agent, agentId) : undefined;
+        return this.handleSubagentStop(agent, agentId, provider, normEvent);
       case 'permissionRequest':
         // Handles BOTH the PermissionRequest hook AND the Notification(permission_prompt)
         // hook -- normalizeHookEvent collapses them into one event kind.
@@ -346,16 +365,16 @@ export class HookEventHandler {
         // Handles Stop AND Notification(idle_prompt) -- both normalize to turnEnd.
         // awaitingInput discriminates them: idle_prompt sets it (-> "Waiting for
         // input"), Stop leaves it absent (-> "Done").
-        return this.handleStop(agent, agentId, normEvent.awaitingInput === true);
+        return this.handleStop(agent, agentId, provider, normEvent.awaitingInput === true);
       case 'subagentTurnEnd':
         // Handles TeammateIdle AND TaskCompleted -- both normalize here. The normalized
         // `reason` field discriminates; the team-provider's extractTeammateNameFromEvent(raw)
         // still routes to the specific teammate. (TaskCreated normalizes to null in the provider.)
-        if (!this.provider.team) return;
+        if (!provider.team) return;
         if (normEvent.reason === 'completed') {
-          return this.handleTaskCompleted(event, agentId);
+          return this.handleTaskCompleted(event, agentId, provider);
         }
-        return this.handleTeammateIdle(event, agent, agentId);
+        return this.handleTeammateIdle(event, agent, agentId, provider);
       case 'progress':
         // Not yet consumed by the office visualization. Silently drop.
         return;
@@ -370,6 +389,7 @@ export class HookEventHandler {
     normEvent: Extract<AgentEvent, { kind: 'sessionEnd' }>,
     agent: AgentState,
     agentId: number,
+    provider: HookProvider,
   ): void {
     const reason = normEvent.reason;
     if (debug)
@@ -383,7 +403,7 @@ export class HookEventHandler {
 
     if (expectsFollowUp) {
       agent.pendingClear = true;
-      this.markAgentWaiting(agent, agentId);
+      this.markAgentWaiting(agent, agentId, provider);
       if (debug)
         console.log(
           `[Pixel Agents] Hook: Agent ${agentId} - SessionEnd(reason=${reason}), awaiting possible SessionStart`,
@@ -398,7 +418,7 @@ export class HookEventHandler {
     } else {
       // Immediate cleanup for exit/logout. onSessionEnd → removeTeammates in the
       // ViewProvider cleans up all teammates of this lead at once.
-      this.markAgentWaiting(agent, agentId);
+      this.markAgentWaiting(agent, agentId, provider);
       this.lifecycleCallbacks.onSessionEnd?.(agentId, reason ?? 'unknown');
     }
   }
@@ -412,11 +432,17 @@ export class HookEventHandler {
     normEvent: Extract<AgentEvent, { kind: 'toolStart' }>,
     agent: AgentState,
     agentId: number,
+    provider: HookProvider,
   ): void {
     const toolName = normEvent.toolName;
     const toolInput = (normEvent.input as Record<string, unknown> | undefined) ?? {};
-    const status = this.provider.formatToolStatus(toolName, toolInput);
-    const hookToolId = `hook-${Date.now()}`;
+    const status = provider.formatToolStatus(toolName, toolInput);
+    // The hook tool id comes from normalization, not from here: providers whose
+    // payloads carry a stable call id (OpenCode) mint `hook-<callId>` there, so
+    // SubagentStart's parentToolId correlates with this exact value. Minting a
+    // second timestamp id here would break that correlation; for Claude the
+    // normalized id is itself `hook-<Date.now()>`, so behavior is unchanged.
+    const hookToolId = normEvent.toolId;
 
     // Track for PostToolUse/SubagentStart correlation (always, even if suppressed below).
     // currentHookIsTeammateSpawn is the authoritative teammate-vs-subagent discriminator.
@@ -424,7 +450,7 @@ export class HookEventHandler {
     agent.currentHookToolId = hookToolId;
     agent.currentHookToolName = toolName;
     agent.currentHookIsTeammateSpawn =
-      this.provider.team?.isTeammateSpawnCall(toolName, toolInput) ?? false;
+      provider.team?.isTeammateSpawnCall(toolName, toolInput) ?? false;
 
     // When a lead has inline teammates, hook tool events are ambiguous (could be
     // from the lead or any teammate -- they share session_id). Suppress hook-originated
@@ -438,11 +464,14 @@ export class HookEventHandler {
     agent.hadToolsInTurn = true;
 
     // Send tool start + active state to webview (instant, no 500ms JSONL delay).
-    // Skip for Task/Agent tools — their sub-agent characters need the stable JSONL
+    // Skip for subagent-spawning tools — their sub-agent characters need the stable JSONL
     // tool ID (not the transient hook ID) so that SubagentStop/tool_result cleanup
     // can find and remove them. JSONL handles agentToolStart (with runInBackground)
-    // for these tools.
-    if (toolName !== 'Task' && toolName !== 'Agent') {
+    // for these tools. Providers without a transcript (OpenCode) have no JSONL, so
+    // nothing is skipped for them: the hook display is their only display.
+    // The suppressed set IS the provider's subagentToolNames — for Claude that is
+    // exactly Task/Agent, preserving the long-standing behavior byte for byte.
+    if (!provider.subagentToolNames.has(toolName)) {
       this.agents.broadcast({
         type: 'agentToolStart',
         id: agentId,
@@ -492,8 +521,14 @@ export class HookEventHandler {
    * For old-style Task/Agent subagents (inline, no run_in_background), creates
    * the child character immediately via hooks without waiting for JSONL polling.
    */
-  private handleSubagentStart(event: HookEvent, agent: AgentState, agentId: number): void {
-    const agentType = this.provider.team?.extractTeammateNameFromEvent(event) ?? 'unknown';
+  private handleSubagentStart(
+    event: HookEvent,
+    agent: AgentState,
+    agentId: number,
+    provider: HookProvider,
+    normEvent: Extract<AgentEvent, { kind: 'subagentStart' }>,
+  ): void {
+    const agentType = provider.team?.extractTeammateNameFromEvent(event) ?? normEvent.toolName;
 
     // Decide path: teammate spawn vs basic within-turn subagent.
     // Two conditions must BOTH hold for the teammate path:
@@ -503,7 +538,7 @@ export class HookEventHandler {
     //      Without this guard, external sessions firing run_in_background=true
     //      for parallel basic subagents would be mis-routed to teammate discovery.
     // Mirrors the same gate used by the periodic scanAllTeammateFiles fallback.
-    if (this.provider.team && agent.currentHookIsTeammateSpawn === true && agent.teamName) {
+    if (provider.team && agent.currentHookIsTeammateSpawn === true && agent.teamName) {
       if (debug)
         console.log(
           `[Pixel Agents] Hook: Agent ${agentId} - SubagentStart: teammate "${agentType}" detected, triggering discovery`,
@@ -515,7 +550,7 @@ export class HookEventHandler {
     // Basic within-turn subagent path: find parent tool ID from activeToolNames.
     // Use only the real JSONL-populated id -- no synthetic fallback here, or we'd
     // double-track parents once JSONL catches up.
-    const parentTools = this.getSubagentToolSet();
+    const parentTools = this.getSubagentToolSet(provider);
     let parentToolId: string | undefined;
     for (const [toolId, toolName] of agent.activeToolNames) {
       if (parentTools.has(toolName)) {
@@ -523,11 +558,25 @@ export class HookEventHandler {
         break;
       }
     }
-    if (!parentToolId) return; // JSONL will handle it via agent_progress tool_use
+    if (!parentToolId) {
+      // Hook fallback for transcript-less providers (OpenCode): the normalized
+      // parent id is `hook-<callId>`, the same value handlePreToolUse stored as
+      // currentHookToolId for the sibling task call. JSONL-backed providers
+      // normalize the 'current' sentinel here, which never equals a real id, so
+      // their behavior is unchanged: JSONL still handles it via agent_progress.
+      if (
+        normEvent.parentToolId.startsWith('hook-') &&
+        normEvent.parentToolId === agent.currentHookToolId
+      ) {
+        parentToolId = normEvent.parentToolId;
+      } else {
+        return; // JSONL will handle it via agent_progress tool_use
+      }
+    }
 
     // Create child sub-agent character immediately (same as old behavior).
-    const subToolId = `hook-sub-${agentType}-${Date.now()}`;
-    const status = `Subtask: ${agentType}`;
+    const subToolId = normEvent.toolId;
+    const status = `Subtask: ${normEvent.toolName}`;
 
     // Track sub-agent
     let subTools = agent.activeSubagentToolIds.get(parentToolId);
@@ -561,7 +610,12 @@ export class HookEventHandler {
    *
    * For old-style Task subagents: removes the child character from the office.
    */
-  private handleSubagentStop(agent: AgentState, agentId: number): void {
+  private handleSubagentStop(
+    agent: AgentState,
+    agentId: number,
+    provider: HookProvider,
+    normEvent: Extract<AgentEvent, { kind: 'subagentEnd' }>,
+  ): void {
     // Check if this agent has inline teammates (independent agents with leadAgentId).
     // Just mark them waiting -- SubagentStop fires per-task-iteration; teammates may
     // sit idle for minutes between lead requests before being re-invoked.
@@ -576,7 +630,7 @@ export class HookEventHandler {
           `[Pixel Agents] Hook: Agent ${agentId} - SubagentStop: marking inline teammates as waiting`,
         );
       for (const [id, a] of inlineTeammates) {
-        this.markAgentWaiting(a, id);
+        this.markAgentWaiting(a, id, provider);
       }
       return;
     }
@@ -585,7 +639,7 @@ export class HookEventHandler {
     // sub-agents. The `activeSubagentToolIds.has(toolId)` gate below prevents us
     // from picking a subagent-spawning parent that already had its sub-agents
     // cleared in the same turn.
-    const subagentParentTools = this.getSubagentToolSet();
+    const subagentParentTools = this.getSubagentToolSet(provider);
     let parentToolId: string | undefined;
     for (const [toolId, toolName] of agent.activeToolNames) {
       if (subagentParentTools.has(toolName) && agent.activeSubagentToolIds.has(toolId)) {
@@ -593,7 +647,17 @@ export class HookEventHandler {
         break;
       }
     }
-    if (!parentToolId) return; // JSONL will handle it via agent_progress tool_result
+    if (!parentToolId) {
+      // Hook fallback for transcript-less providers (OpenCode): the normalized
+      // parent id is `hook-<callId>`, under which handleSubagentStart tracked
+      // the sub. JSONL-backed providers normalize the 'current' sentinel, which
+      // is never a map key, so their behavior is unchanged: JSONL handles it.
+      if (agent.activeSubagentToolIds.has(normEvent.parentToolId)) {
+        parentToolId = normEvent.parentToolId;
+      } else {
+        return; // JSONL will handle it via agent_progress tool_result
+      }
+    }
 
     agent.activeSubagentToolIds.delete(parentToolId);
     agent.activeSubagentToolNames.delete(parentToolId);
@@ -635,8 +699,13 @@ export class HookEventHandler {
   }
 
   /** Handle Stop: Claude finished responding, mark agent as waiting. */
-  private handleStop(agent: AgentState, agentId: number, awaitingInput = false): void {
-    this.markAgentWaiting(agent, agentId, awaitingInput);
+  private handleStop(
+    agent: AgentState,
+    agentId: number,
+    provider: HookProvider,
+    awaitingInput = false,
+  ): void {
+    this.markAgentWaiting(agent, agentId, provider, awaitingInput);
   }
 
   /**
@@ -645,13 +714,18 @@ export class HookEventHandler {
    * marks all inline teammates of this lead as waiting.
    * Fallback: if the agent has no inline teammates, mark the agent itself.
    */
-  private handleTeammateIdle(event: HookEvent, agent: AgentState, agentId: number): void {
-    const teammateName = this.provider.team?.extractTeammateNameFromEvent(event);
+  private handleTeammateIdle(
+    event: HookEvent,
+    agent: AgentState,
+    agentId: number,
+    provider: HookProvider,
+  ): void {
+    const teammateName = provider.team?.extractTeammateNameFromEvent(event);
     const inlineTeammates = getInlineTeammates(agentId, this.agents);
 
     if (inlineTeammates.length === 0) {
       // No inline teammates — treat as a completed turn for this agent.
-      this.markAgentWaiting(agent, agentId);
+      this.markAgentWaiting(agent, agentId, provider);
       return;
     }
 
@@ -664,7 +738,7 @@ export class HookEventHandler {
           console.log(
             `[Pixel Agents] Hook: TeammateIdle "${teammateName}" -> teammate Agent ${id}`,
           );
-        this.markAgentWaiting(a, id);
+        this.markAgentWaiting(a, id, provider);
         return;
       }
     }
@@ -675,7 +749,7 @@ export class HookEventHandler {
         `[Pixel Agents] Hook: TeammateIdle (no teammate_name match) -> marking ${inlineTeammates.length} teammate(s) done`,
       );
     for (const [id, a] of inlineTeammates) {
-      this.markAgentWaiting(a, id);
+      this.markAgentWaiting(a, id, provider);
     }
   }
 
@@ -683,14 +757,14 @@ export class HookEventHandler {
    * Handle TaskCompleted: a teammate marked its task done.
    * Routes to the specific teammate when identifiable, marking it waiting instantly.
    */
-  private handleTaskCompleted(event: HookEvent, agentId: number): void {
+  private handleTaskCompleted(event: HookEvent, agentId: number, provider: HookProvider): void {
     const taskSubject =
       typeof event.task_subject === 'string'
         ? event.task_subject
         : typeof event.subject === 'string'
           ? event.subject
           : '';
-    const teammateName = this.provider.team?.extractTeammateNameFromEvent(event);
+    const teammateName = provider.team?.extractTeammateNameFromEvent(event);
     if (debug)
       console.log(
         `[Pixel Agents] Hook: Agent ${agentId} - TaskCompleted: ${taskSubject}${teammateName ? ` (teammate_name=${teammateName})` : ''}`,
@@ -704,12 +778,12 @@ export class HookEventHandler {
       const match = inlineTeammates.find(([, a]) => a.agentName === teammateName);
       if (match) {
         const [id, a] = match;
-        this.markAgentWaiting(a, id);
+        this.markAgentWaiting(a, id, provider);
         return;
       }
     }
     for (const [id, a] of inlineTeammates) {
-      this.markAgentWaiting(a, id);
+      this.markAgentWaiting(a, id, provider);
     }
   }
 
@@ -718,7 +792,12 @@ export class HookEventHandler {
    * agents), cancels timers, and notifies the webview. Same logic as the turn_duration
    * handler in transcriptParser.ts.
    */
-  private markAgentWaiting(agent: AgentState, agentId: number, awaitingInput = false): void {
+  private markAgentWaiting(
+    agent: AgentState,
+    agentId: number,
+    provider: HookProvider,
+    awaitingInput = false,
+  ): void {
     cancelWaitingTimer(agentId, this.waitingTimers);
     cancelPermissionTimer(agentId, this.permissionTimers);
 
@@ -726,7 +805,7 @@ export class HookEventHandler {
     // ALWAYS send agentToolsClear at turn end -- even when activeToolIds is empty by now
     // (because tool_results already processed and removed them). Without this, stale
     // sub-agent characters and permission bubbles from the turn would never clear.
-    const parentTools = this.getSubagentToolSet();
+    const parentTools = this.getSubagentToolSet(provider);
     for (const toolId of [...agent.activeToolIds]) {
       if (agent.backgroundAgentToolIds.has(toolId)) continue;
       agent.activeToolIds.delete(toolId);
@@ -740,6 +819,16 @@ export class HookEventHandler {
         // shadow watch too, or it lingers until sessionEnd.
         notifyBackgroundAgentCompleted(agentId, toolId);
       }
+    }
+    // Hook-tracked subagents of transcript-less providers (OpenCode) are keyed
+    // by `hook-<callId>` parent ids that never enter activeToolIds, so the
+    // loop above cannot see them. Purge them explicitly: a `hook-` key can
+    // never be a JSONL tool id, so JSONL-backed providers are unaffected.
+    for (const parentToolId of [...agent.activeSubagentToolIds.keys()]) {
+      if (!parentToolId.startsWith('hook-')) continue;
+      agent.activeSubagentToolIds.delete(parentToolId);
+      agent.activeSubagentToolNames.delete(parentToolId);
+      this.agents.broadcast({ type: 'subagentClear', id: agentId, parentToolId });
     }
     this.agents.broadcast({ type: 'agentToolsClear', id: agentId });
     // Re-send background agent tools to restore them after the clear.

--- a/server/src/providers/hook/opencode/bridge/pixel-agents-bridge.ts
+++ b/server/src/providers/hook/opencode/bridge/pixel-agents-bridge.ts
@@ -1,0 +1,271 @@
+// Managed by Pixel Agents — bridge plugin that reports OpenCode session activity
+// to a local Pixel Agents server so your agents appear as characters in the
+// office. Safe to delete: removing this file uninstalls the integration.
+// Installed by Pixel Agents (never hand-edit; reinstall to refresh).
+
+import * as fs from 'node:fs';
+import * as http from 'node:http';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+// ── Server discovery (mirrors the claude-hook.js registry protocol) ─────────
+// Every live server registers one record under ~/.pixel-agents/servers/; a
+// legacy single-target ~/.pixel-agents/server.json is the fallback. Records
+// carry { port, pid, token } — validated minimally here so a foreign or
+// half-written file can never divert an event (or the bearer token) elsewhere.
+
+const PIXEL_AGENTS_DIR = path.join(os.homedir(), '.pixel-agents');
+const SERVERS_REGISTRY_DIR = path.join(PIXEL_AGENTS_DIR, 'servers');
+const LEGACY_SERVER_JSON = path.join(PIXEL_AGENTS_DIR, 'server.json');
+const HOOK_API_PATH = '/api/hooks/opencode';
+const POST_TIMEOUT_MS = 2000;
+
+interface ServerTarget {
+  port: number;
+  pid: number;
+  token: string;
+}
+
+let debugLogPath = process.env['PIXEL_AGENTS_DEBUG_LOG'];
+
+function bridgeDebug(line: string): void {
+  if (!debugLogPath) return;
+  try {
+    fs.appendFileSync(debugLogPath, `${new Date().toISOString()} OPENCODE-BRIDGE ${line}\n`);
+  } catch {
+    /* never let diagnostics break the bridge */
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function asServerTarget(value: unknown): ServerTarget | null {
+  if (!isRecord(value)) return null;
+  const { port, pid, token } = value;
+  if (!Number.isSafeInteger(port) || (port as number) < 1 || (port as number) > 65535) return null;
+  if (!Number.isSafeInteger(pid) || (pid as number) <= 0) return null;
+  if (typeof token !== 'string' || token.length === 0) return null;
+  return { port: port as number, pid: pid as number, token };
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function readRegistry(): ServerTarget[] {
+  let files: string[];
+  try {
+    files = fs.readdirSync(SERVERS_REGISTRY_DIR).filter((f) => f.endsWith('.json'));
+  } catch {
+    return [];
+  }
+  const live: ServerTarget[] = [];
+  for (const file of files) {
+    try {
+      const target = asServerTarget(
+        JSON.parse(fs.readFileSync(path.join(SERVERS_REGISTRY_DIR, file), 'utf-8')),
+      );
+      if (!target) continue;
+      if (isProcessAlive(target.pid)) live.push(target);
+    } catch {
+      /* malformed entry: skip */
+    }
+  }
+  return live;
+}
+
+function postToServer(server: ServerTarget, body: string): Promise<void> {
+  return new Promise((resolve) => {
+    try {
+      const req = http.request(
+        {
+          hostname: '127.0.0.1',
+          port: server.port,
+          path: HOOK_API_PATH,
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Content-Length': Buffer.byteLength(body),
+            Authorization: `Bearer ${server.token}`,
+          },
+          timeout: POST_TIMEOUT_MS,
+        },
+        (res) => {
+          res.resume();
+          resolve();
+        },
+      );
+      req.on('error', () => resolve());
+      req.on('timeout', () => {
+        req.destroy();
+        resolve();
+      });
+      req.end(body);
+    } catch {
+      resolve();
+    }
+  });
+}
+
+/** Best-effort fan-out. Fire-and-forget: callers must `void` this, never
+ *  await it — awaiting would stall the tool call or session transition that
+ *  fired the event while the POST is in flight. */
+function emit(envelope: Record<string, unknown>): void {
+  const sid =
+    typeof envelope['session_id'] === 'string'
+      ? (envelope['session_id'] as string).slice(0, 8)
+      : '?';
+  const eventName =
+    typeof envelope['hook_event_name'] === 'string' ? (envelope['hook_event_name'] as string) : '?';
+  bridgeDebug(`emit event=${eventName} sid=${sid}`);
+  let servers = readRegistry();
+  if (servers.length === 0) {
+    try {
+      const legacy = asServerTarget(JSON.parse(fs.readFileSync(LEGACY_SERVER_JSON, 'utf-8')));
+      servers = legacy && isProcessAlive(legacy.pid) ? [legacy] : [];
+    } catch {
+      servers = [];
+    }
+  }
+  if (servers.length === 0) {
+    bridgeDebug(`exit reason=no-server-json event=${eventName} sid=${sid}`);
+    return;
+  }
+  const body = JSON.stringify(envelope);
+  void Promise.all(servers.map((server) => postToServer(server, body)));
+}
+
+// ── OpenCode event → hook envelope ───────────────────────────────────────────
+// The envelope reuses the hook vocabulary the server route already accepts
+// (hook_event_name + session_id, see server/src/httpServer.ts), so the
+// OpenCode provider normalizes these exactly like Claude hook payloads.
+
+function str(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function record(value: unknown): Record<string, unknown> {
+  return isRecord(value) ? value : {};
+}
+
+/** Last session seen on any event. Permission prompts do not always carry a
+ *  session id, so they fall back to this rather than being dropped. */
+let lastSessionId: string | undefined;
+
+function trackSession(sessionId: string | undefined): string | undefined {
+  if (sessionId) lastSessionId = sessionId;
+  return sessionId;
+}
+
+function sessionStart(info: Record<string, unknown>): void {
+  const sessionId = trackSession(str(info['id']));
+  if (!sessionId) return;
+  emit({
+    hook_event_name: 'SessionStart',
+    session_id: sessionId,
+    source: 'opencode',
+    cwd: str(info['directory']),
+  });
+}
+
+function sessionEnd(info: Record<string, unknown>): void {
+  const sessionId = trackSession(str(info['id']));
+  if (!sessionId) return;
+  emit({ hook_event_name: 'SessionEnd', session_id: sessionId, reason: 'exit' });
+}
+
+function toolBefore(input: Record<string, unknown>): void {
+  const tool = str(input['tool']);
+  const sessionId = trackSession(str(input['sessionID']));
+  if (!tool || !sessionId) return;
+  const args = record(input['args']);
+  const callId = str(input['callID']);
+  const subagentType = str(args['subagent_type']);
+  if (tool === 'task' && subagentType) {
+    emit({
+      hook_event_name: 'SubagentStart',
+      session_id: sessionId,
+      tool_name: subagentType,
+      tool_input: { description: str(args['description']), call_id: callId },
+      call_id: callId,
+    });
+    return;
+  }
+  emit({
+    hook_event_name: 'PreToolUse',
+    session_id: sessionId,
+    tool_name: tool,
+    tool_input: args,
+    call_id: callId,
+  });
+}
+
+function toolAfter(input: Record<string, unknown>, output: Record<string, unknown>): void {
+  const tool = str(input['tool']);
+  const sessionId = trackSession(str(input['sessionID']));
+  if (!tool || !sessionId) return;
+  const args = record(input['args']);
+  const callId = str(input['callID']);
+  const metadata = record(output['metadata']);
+  const exitCode = metadata['exit'];
+  const failed = typeof exitCode === 'number' && exitCode !== 0;
+  const subagentType = str(args['subagent_type']);
+  if (tool === 'task' && subagentType) {
+    emit({ hook_event_name: 'SubagentStop', session_id: sessionId, call_id: callId });
+    return;
+  }
+  emit({
+    hook_event_name: failed ? 'PostToolUseFailure' : 'PostToolUse',
+    session_id: sessionId,
+    call_id: callId,
+  });
+}
+
+function permissionPrompt(input: Record<string, unknown>): void {
+  const sessionId = trackSession(str(input['sessionID'])) ?? lastSessionId;
+  if (!sessionId) return;
+  emit({ hook_event_name: 'PermissionRequest', session_id: sessionId });
+}
+
+// ── Plugin ───────────────────────────────────────────────────────────────────
+// One named export, the shape OpenCode's plugin loader calls with its context.
+// Handlers stay synchronous and fire-and-forget: nothing here may delay the
+// tool call or session transition being reported.
+//
+// Event keys follow the documented OpenCode plugin events. `permission.ask`
+// is kept as an alias next to the documented `permission.asked`: unknown keys
+// are inert (OpenCode only invokes handlers for events it fires), while a
+// renamed key without its alias would silently lose the permission bubble.
+
+export const PixelAgents = async () => ({
+  'session.created': (input: Record<string, unknown>) => {
+    sessionStart(record(input['info']));
+  },
+  'session.deleted': (input: Record<string, unknown>) => {
+    sessionEnd(record(input['info']));
+  },
+  'session.idle': (input: Record<string, unknown>) => {
+    const sessionId = trackSession(str(input['sessionID']));
+    if (!sessionId) return;
+    emit({ hook_event_name: 'Stop', session_id: sessionId });
+  },
+  'tool.execute.before': (input: Record<string, unknown>) => {
+    toolBefore(input);
+  },
+  'tool.execute.after': (input: Record<string, unknown>, output: Record<string, unknown>) => {
+    toolAfter(input, output ?? {});
+  },
+  'permission.asked': (input: Record<string, unknown>) => {
+    permissionPrompt(input);
+  },
+  'permission.ask': (input: Record<string, unknown>) => {
+    permissionPrompt(input);
+  },
+});

--- a/server/src/providers/hook/opencode/consentCopy.ts
+++ b/server/src/providers/hook/opencode/consentCopy.ts
@@ -1,0 +1,55 @@
+/**
+ * Disclosure text for the hooks consent gate, OpenCode provider. Both surfaces
+ * show the SAME in-app ask: the server ships these strings in the
+ * `hooksConsentRequest` message and the webview's IntroBubble renders them
+ * verbatim, so there is exactly one copy of the terms and no client-side
+ * duplicate to drift.
+ *
+ * Two pieces: the HEADLINE is the title of the Intro's consent step and the
+ * DISCLOSURE is that step's body. The headline carries NO disclosure facts —
+ * every fact lives in the shared disclosure block (consentCopy.test.ts pins
+ * that split for the Claude copy; the same shape is honored here).
+ */
+
+import { OPENCODE_PLUGIN_FILE_NAME } from './constants.js';
+
+/** Plugin destination as shown to the user. A static display string, not a
+ *  computed path: this module loads wherever the provider registry loads
+ *  (including test processes with a mocked `os`), and calling os.homedir()
+ *  at import time crashes those. The installer owns the real path
+ *  (getBridgePluginPath); this copy only names the conventional location. */
+const PLUGIN_DESTINATION = `~/.config/opencode/plugins/${OPENCODE_PLUGIN_FILE_NAME}`;
+
+/** WHY we ask + WHAT we write. */
+export const OPENCODE_CONSENT_FACT_WHAT =
+  `To bring your OpenCode agents to life in real time, Pixel Agents adds a ` +
+  `small bridge plugin to OpenCode's global plugin directory (${PLUGIN_DESTINATION}). ` +
+  `Note that your existing OpenCode config is never modified — the plugin is a ` +
+  `single new file, and removing that file uninstalls the integration.`;
+
+/** WHAT data moves, and where it stops.
+ *
+ *  "Nothing leaves your machine" is not something this prompt can promise:
+ *  `npx pixel-agents --host 0.0.0.0` binds the same server to every interface,
+ *  and an accepted socket receives the store broadcasts
+ *  (server/src/httpServer.ts). So it states the default and names the one
+ *  thing that changes it, rather than making a promise the software can be
+ *  asked to break. */
+export const OPENCODE_CONSENT_FACT_DATA =
+  'OpenCode will send session and tool events - including tool names and tool inputs - to a Pixel Agents ' +
+  'server on this machine. Everything stays local - the server listens only on 127.0.0.1 - unless ' +
+  'you explicitly start it with --host to expose it on your network.';
+
+/** HOW to undo it. */
+export const OPENCODE_CONSENT_FACT_REVERSIBLE =
+  'You can remove the bridge plugin at any time from Settings → Instant Detection (Hooks).';
+
+/** Headline for the first-run gate. Carries NO disclosure facts by design. */
+export const OPENCODE_CONSENT_INSTALL_HEADLINE = 'One more thing: OpenCode hooks!';
+
+/** The three disclosure facts, in order, as one block. */
+export const OPENCODE_CONSENT_DISCLOSURE = [
+  OPENCODE_CONSENT_FACT_WHAT,
+  OPENCODE_CONSENT_FACT_DATA,
+  OPENCODE_CONSENT_FACT_REVERSIBLE,
+].join('\n\n');

--- a/server/src/providers/hook/opencode/constants.ts
+++ b/server/src/providers/hook/opencode/constants.ts
@@ -1,0 +1,54 @@
+/**
+ * OpenCode-specific constants. Kept separate from `server/src/constants.ts` so a
+ * future single-provider `server/` build doesn't accidentally depend on OpenCode
+ * unless OpenCode is the active provider.
+ *
+ * Adding another provider? Create its own `providers/<kind>/<name>/constants.ts`.
+ */
+
+import * as os from 'os';
+import * as path from 'path';
+
+/** Provider id used on the wire (`POST /api/hooks/opencode`). Must match the
+ *  route pattern `^[a-z0-9-]+$` in `server/src/httpServer.ts`. */
+export const OPENCODE_PROVIDER_ID = 'opencode';
+
+/** Filename of the bridge plugin as installed into OpenCode's global plugin
+ *  directory (`~/.config/opencode/plugins/`). OpenCode loads it directly with
+ *  Bun, so no bundling step is involved — the file is copied verbatim. */
+export const OPENCODE_PLUGIN_FILE_NAME = 'pixel-agents.ts';
+
+/** Filename of the bridge source inside this package (`dist/bridge/` after
+ *  build, `bridge/` next to this file in source). */
+export const OPENCODE_BRIDGE_SOURCE_NAME = 'pixel-agents-bridge.ts';
+
+/** Subdirectory of `dist/` the build copies the bridge source into. */
+export const OPENCODE_BRIDGE_DIST_DIR = 'bridge';
+
+/** Marker comment the bridge source carries on its first line. Install state
+ *  is file identity, not settings surgery: a plugin file containing this
+ *  marker is ours to refresh; a file without it is the user's and is never
+ *  touched (install aborts instead). */
+export const OPENCODE_PLUGIN_MARKER = 'Managed by Pixel Agents';
+
+/** Suffix of the temp file used for the atomic tmp-write + rename. */
+export const OPENCODE_PLUGIN_TMP_SUFFIX = '.pixel-agents-tmp';
+
+/** Mode for the plugins directory and plugin file we create. The file carries
+ *  no secrets (the server token is read from `~/.pixel-agents/servers/` at
+ *  event time, never written into the plugin), but restrictive-by-default
+ *  matches the hook-script installer. */
+export const OPENCODE_PLUGIN_DIR_MODE = 0o700;
+export const OPENCODE_PLUGIN_FILE_MODE = 0o600;
+
+/** Terminal name prefix for OpenCode sessions launched from the extension.
+ *  Reserved for terminal→agent adoption if the VS Code adapter ever launches
+ *  OpenCode terminals; the file-watcher heuristic consults it the same way it
+ *  consults the Claude prefix. */
+export const OPENCODE_TERMINAL_NAME_PREFIX = 'opencode';
+
+/** Returns the destination path of the installed bridge plugin
+ *  (`~/.config/opencode/plugins/pixel-agents.ts`). */
+export function getBridgePluginPath(): string {
+  return path.join(os.homedir(), '.config', 'opencode', 'plugins', OPENCODE_PLUGIN_FILE_NAME);
+}

--- a/server/src/providers/hook/opencode/opencode.ts
+++ b/server/src/providers/hook/opencode/opencode.ts
@@ -1,0 +1,232 @@
+import * as path from 'path';
+
+import type { AgentEvent, HookProvider } from '../../../../../core/src/provider.js';
+import {
+  BASH_COMMAND_DISPLAY_MAX_LENGTH,
+  TASK_DESCRIPTION_DISPLAY_MAX_LENGTH,
+} from '../../../constants.js';
+import { OPENCODE_CONSENT_DISCLOSURE, OPENCODE_CONSENT_INSTALL_HEADLINE } from './consentCopy.js';
+import { OPENCODE_PROVIDER_ID, OPENCODE_TERMINAL_NAME_PREFIX } from './constants.js';
+import {
+  areHooksInstalled as installerAreHooksInstalled,
+  installHooks as installerInstallHooks,
+  uninstallHooks as installerUninstallHooks,
+} from './opencodeBridgeInstaller.js';
+
+// ── formatToolStatus ──
+//
+// Status prefixes deliberately reuse the Claude vocabulary ("Reading x.ts",
+// "Running: …", "Subtask: …"): the webview maps status → animation by prefix
+// (webview-ui/src/office/toolUtils.ts), so sharing prefixes keeps every
+// animation correct with no webview change.
+
+export function formatToolStatus(toolName: string, input?: unknown): string {
+  const inp = (input ?? {}) as Record<string, unknown>;
+  const base = (p: unknown) => (typeof p === 'string' ? path.basename(p) : '');
+  switch (toolName) {
+    case 'read':
+      return `Reading ${base(inp.path ?? inp.filePath)}`;
+    case 'edit':
+      return `Editing ${base(inp.filePath)}`;
+    case 'write':
+      return `Writing ${base(inp.filePath)}`;
+    case 'bash': {
+      const cmd = typeof inp.command === 'string' ? inp.command : '';
+      return `Running: ${cmd.length > BASH_COMMAND_DISPLAY_MAX_LENGTH ? cmd.slice(0, BASH_COMMAND_DISPLAY_MAX_LENGTH) + '…' : cmd}`;
+    }
+    case 'glob':
+      return 'Searching files';
+    case 'grep':
+      return 'Searching code';
+    case 'webfetch':
+      return 'Fetching web content';
+    case 'websearch':
+      return 'Searching the web';
+    case 'task': {
+      const desc = typeof inp.description === 'string' ? inp.description : '';
+      return desc
+        ? `Subtask: ${desc.length > TASK_DESCRIPTION_DISPLAY_MAX_LENGTH ? desc.slice(0, TASK_DESCRIPTION_DISPLAY_MAX_LENGTH) + '…' : desc}`
+        : 'Running subtask';
+    }
+    case 'skill': {
+      const name = typeof inp.name === 'string' ? inp.name : '';
+      return name ? `Using skill ${name}` : 'Using skill';
+    }
+    case 'question':
+      return 'Waiting for your answer';
+    case 'todowrite':
+      return 'Updating todos';
+    default:
+      return `Using ${toolName}`;
+  }
+}
+
+// ── buildLaunchCommand ──
+//
+// Reserved for a future "+ Agent" surface that launches OpenCode terminals:
+// `opencode` starts a fresh session in the workspace directory. The sessionId
+// is unused — OpenCode has no stable resume-by-id CLI flag to target — so the
+// parameter is underscore-prefixed per the repo's noUnusedParameters policy.
+
+function buildLaunchCommand(
+  _sessionId: string,
+  cwd: string,
+): { command: string; args: string[]; env?: Record<string, string> } {
+  return { command: 'opencode', args: [], env: { PWD: cwd } };
+}
+
+// ── normalizeHookEvent: the single OpenCode-specific normalization boundary ──
+//
+// The bridge plugin (bridge/pixel-agents-bridge.ts) already translates OpenCode
+// bus events into this envelope vocabulary, so only THESE fields are read here
+// and HERE ONLY. Downstream (hookEventHandler.ts) sees only the normalized
+// AgentEvent union.
+//
+// `call_id` (the OpenCode tool call id) becomes the stable hook tool id, where
+// Claude mints `hook-<Date.now()>` because its payload carries no id. A stable
+// id is strictly better for Pre/Post correlation; the handler's 'current'
+// sentinel path is untouched.
+//
+// Subagent envelopes (task calls carrying subagent_type) arrive as
+// SubagentStart/SubagentStop with the subagent type as tool_name and the
+// parent task's call_id as call_id. normalize maps the parent to
+// `hook-<call_id>` — the same id the sibling PreToolUse path would have
+// minted — so the handler's hook-fallback parent resolution correlates them
+// without any JSONL. A missing call_id degrades to the 'current' sentinel,
+// exactly like Claude.
+
+function normalizeHookEvent(
+  raw: Record<string, unknown>,
+): { sessionId: string; event: AgentEvent } | null {
+  const eventName = raw.hook_event_name;
+  const sessionId = raw.session_id;
+  if (typeof eventName !== 'string' || typeof sessionId !== 'string') return null;
+  const callId = typeof raw.call_id === 'string' && raw.call_id.length > 0 ? raw.call_id : null;
+  const toolId = callId ? `hook-${callId}` : `hook-${Date.now()}`;
+
+  switch (eventName) {
+    case 'PreToolUse': {
+      const toolName = typeof raw.tool_name === 'string' ? raw.tool_name : '';
+      const toolInput =
+        typeof raw.tool_input === 'object' && raw.tool_input !== null
+          ? (raw.tool_input as Record<string, unknown>)
+          : {};
+      return {
+        sessionId,
+        event: { kind: 'toolStart', toolId, toolName, input: toolInput },
+      };
+    }
+
+    case 'PostToolUse':
+    case 'PostToolUseFailure':
+      return { sessionId, event: { kind: 'toolEnd', toolId: 'current' } };
+
+    case 'Stop':
+      return { sessionId, event: { kind: 'turnEnd' } };
+
+    case 'SubagentStart': {
+      const agentType = typeof raw.tool_name === 'string' ? raw.tool_name : 'unknown';
+      return {
+        sessionId,
+        event: {
+          kind: 'subagentStart',
+          parentToolId: callId ? `hook-${callId}` : 'current',
+          toolId: `hook-sub-${agentType}-${callId ?? Date.now()}`,
+          toolName: agentType,
+          input: raw.tool_input ?? {},
+        },
+      };
+    }
+
+    case 'SubagentStop':
+      return {
+        sessionId,
+        event: {
+          kind: 'subagentEnd',
+          parentToolId: callId ? `hook-${callId}` : 'current',
+          toolId: 'current',
+        },
+      };
+
+    case 'PermissionRequest':
+      return { sessionId, event: { kind: 'permissionRequest' } };
+
+    case 'SessionStart':
+      return {
+        sessionId,
+        event: {
+          kind: 'sessionStart',
+          source: typeof raw.source === 'string' ? raw.source : undefined,
+          cwd: typeof raw.cwd === 'string' ? raw.cwd : undefined,
+        },
+      };
+
+    case 'SessionEnd':
+      return {
+        sessionId,
+        event: {
+          kind: 'sessionEnd',
+          reason: typeof raw.reason === 'string' ? raw.reason : undefined,
+        },
+      };
+
+    default:
+      return null;
+  }
+}
+
+// ── Installer wrappers: adapt sync signatures to async interface ──
+
+/** Async so an installer throw always reaches callers as a rejection they can
+ *  surface, never a sync throw. */
+async function installHooks(_serverUrl: string, _authToken: string): Promise<void> {
+  await installerInstallHooks();
+}
+
+async function uninstallHooks(): Promise<void> {
+  await installerUninstallHooks();
+}
+
+function areHooksInstalled(): Promise<boolean> {
+  return Promise.resolve(installerAreHooksInstalled());
+}
+
+/** This provider's first-run consent terms. The strings live in
+ *  consentCopy.ts; the shared consent gate ships them verbatim. */
+function consentDisclosure(): { headline: string; disclosure: string } {
+  return { headline: OPENCODE_CONSENT_INSTALL_HEADLINE, disclosure: OPENCODE_CONSENT_DISCLOSURE };
+}
+
+// ── The provider ──
+//
+// Hooks-only: OpenCode persists sessions in a SQLite database
+// (~/.local/share/opencode/opencode.db), not line-delimited transcripts, so
+// there is no file fallback to implement — getSessionDirs,
+// getAllSessionRoots, sessionFilePattern, and parseTranscriptLine are
+// deliberately absent. Every state the office shows arrives over hooks.
+//
+// No team extension in the MVP: task subagents render as basic sub-agent
+// characters via the handler's hook-fallback parent resolution.
+
+export const opencodeProvider: HookProvider = {
+  kind: 'hook',
+  id: OPENCODE_PROVIDER_ID,
+  displayName: 'OpenCode',
+  protocolVersion: 1,
+
+  normalizeHookEvent,
+
+  installHooks,
+  uninstallHooks,
+  areHooksInstalled,
+  consentDisclosure,
+
+  formatToolStatus,
+  permissionExemptTools: new Set(['task', 'question']),
+  subagentToolNames: new Set(['task']),
+  readingTools: new Set(['read', 'glob', 'grep', 'webfetch', 'websearch']),
+  terminalNamePrefix: OPENCODE_TERMINAL_NAME_PREFIX,
+  contextWindowForModel: undefined,
+
+  buildLaunchCommand,
+};

--- a/server/src/providers/hook/opencode/opencodeBridgeInstaller.ts
+++ b/server/src/providers/hook/opencode/opencodeBridgeInstaller.ts
@@ -1,0 +1,156 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+import {
+  getBridgePluginPath,
+  OPENCODE_BRIDGE_DIST_DIR,
+  OPENCODE_BRIDGE_SOURCE_NAME,
+  OPENCODE_PLUGIN_DIR_MODE,
+  OPENCODE_PLUGIN_FILE_MODE,
+  OPENCODE_PLUGIN_MARKER,
+  OPENCODE_PLUGIN_TMP_SUFFIX,
+} from './constants.js';
+
+/** Surfaced when the plugin destination holds a file we did not write. The
+ *  file is the USER's — overwriting it would destroy hand-written config,
+ *  the same class of bug as rewriting a settings file we could not read.
+ *  Refuse instead. */
+export function bridgeForeignFileMessage(pluginPath: string): string {
+  return `${pluginPath} exists but was not installed by Pixel Agents — move or remove it`;
+}
+
+/** Surfaced when installHooks runs without a prior copy step. The copy must
+ *  come first: claiming "installed" over a missing plugin leaves the user
+ *  with a checkbox reading ON and zero events flowing. */
+export const BRIDGE_PLUGIN_MISSING_MESSAGE =
+  'OpenCode bridge plugin is not installed — the copy step must run before install';
+
+/** Returns the shipped bridge source inside an installed package
+ *  (`<packageRoot>/dist/bridge/pixel-agents-bridge.ts`). */
+function getBridgeSourcePath(packageRoot: string): string {
+  return path.join(packageRoot, 'dist', OPENCODE_BRIDGE_DIST_DIR, OPENCODE_BRIDGE_SOURCE_NAME);
+}
+
+/** Best-effort unlink: a leftover tmp file we cannot remove must not mask the
+ *  real error we are already reporting. */
+function removeIfPresent(filePath: string): void {
+  try {
+    fs.rmSync(filePath, { force: true });
+  } catch {
+    /* ignore */
+  }
+}
+
+/**
+ * Whether the Pixel Agents bridge plugin is present in OpenCode's global
+ * plugin directory.
+ *
+ * Identity is the marker comment, not the filename: a same-named file the
+ * user wrote by hand is theirs, and every caller treats it as "not ours".
+ * An unreadable location reads as "not installed" — the install path will
+ * then attempt the write and surface the real error rather than rewriting
+ * blindly.
+ */
+export function areHooksInstalled(): boolean {
+  try {
+    const pluginPath = getBridgePluginPath();
+    if (!fs.existsSync(pluginPath)) return false;
+    return fs.readFileSync(pluginPath, 'utf-8').includes(OPENCODE_PLUGIN_MARKER);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Copy the shipped bridge plugin into OpenCode's global plugin directory.
+ * Returns true if the plugin was copied, false if the source was missing, the
+ * destination holds a foreign file, or the copy failed — so callers report
+ * the failure instead of logging a false success (cf. issue #333: a path
+ * regression silently installed nothing).
+ *
+ * No backup is taken, deliberately: the only content this ever replaces is a
+ * file carrying our own marker (a byte-identical refresh of what we wrote),
+ * mirroring the installer's skip when the replaced settings hold only our
+ * own hooks. Anything else aborts before any write.
+ */
+export function installBridgePlugin(packageRoot: string): boolean {
+  const src = getBridgeSourcePath(packageRoot);
+  const dst = getBridgePluginPath();
+  const dstDir = path.dirname(dst);
+  const tmpPath = dst + OPENCODE_PLUGIN_TMP_SUFFIX;
+
+  try {
+    if (!fs.existsSync(src)) {
+      console.warn(`[Pixel Agents] OpenCode bridge source not found at ${src}`);
+      return false;
+    }
+    if (fs.existsSync(dst)) {
+      let current: string;
+      try {
+        current = fs.readFileSync(dst, 'utf-8');
+      } catch (e) {
+        console.error(`[Pixel Agents] Could not read ${dst}: ${e}`);
+        return false;
+      }
+      if (!current.includes(OPENCODE_PLUGIN_MARKER)) {
+        console.error(`[Pixel Agents] ${bridgeForeignFileMessage(dst)} — hooks not installed.`);
+        return false;
+      }
+    }
+    removeIfPresent(tmpPath);
+    if (!fs.existsSync(dstDir)) {
+      fs.mkdirSync(dstDir, { recursive: true, mode: OPENCODE_PLUGIN_DIR_MODE });
+    }
+    fs.writeFileSync(tmpPath, fs.readFileSync(src), { mode: OPENCODE_PLUGIN_FILE_MODE });
+    fs.chmodSync(tmpPath, OPENCODE_PLUGIN_FILE_MODE);
+    fs.renameSync(tmpPath, dst);
+    console.log(`[Pixel Agents] OpenCode bridge plugin installed at ${dst}`);
+    return true;
+  } catch (e) {
+    removeIfPresent(tmpPath);
+    console.error(`[Pixel Agents] Failed to install OpenCode bridge plugin: ${e}`);
+    return false;
+  }
+}
+
+/**
+ * Verify the bridge plugin install. Idempotent: the copy step (host-owned,
+ * like copyHookScript) does the writing; this asserts the result so a skipped
+ * copy can never report success.
+ *
+ * Rejects when the plugin is absent — callers surface the error to the user
+ * instead of installing.
+ */
+export async function installHooks(): Promise<void> {
+  if (!areHooksInstalled()) {
+    throw new Error(`${BRIDGE_PLUGIN_MISSING_MESSAGE} — hooks not installed.`);
+  }
+  console.log('[Pixel Agents] OpenCode hooks installed (bridge plugin present)');
+}
+
+/** Remove the bridge plugin. Cleans up only what we installed: a foreign file
+ *  at the destination aborts with an error rather than being deleted, and a
+ *  missing file is a silent no-op. Rejects when the file cannot be read —
+ *  same protection as install: never rewrite what we could not read. */
+export async function uninstallHooks(): Promise<void> {
+  const dst = getBridgePluginPath();
+  try {
+    if (!fs.existsSync(dst)) return;
+    let current: string;
+    try {
+      current = fs.readFileSync(dst, 'utf-8');
+    } catch (e) {
+      throw new Error(`Could not read ${dst} — hook entries left in place.`, { cause: e });
+    }
+    if (!current.includes(OPENCODE_PLUGIN_MARKER)) {
+      throw new Error(`${bridgeForeignFileMessage(dst)} — hook entries left in place.`);
+    }
+    fs.rmSync(dst);
+  } catch (e) {
+    if (e instanceof Error && e.message.endsWith('hook entries left in place.')) throw e;
+    throw new Error(`${e instanceof Error ? e.message : String(e)} — hook entries left in place.`, {
+      cause: e,
+    });
+  }
+  console.log('[Pixel Agents] OpenCode bridge plugin removed');
+}

--- a/server/src/providers/index.ts
+++ b/server/src/providers/index.ts
@@ -5,7 +5,7 @@
  *   1. Create `server/src/providers/hook/<cli>/<cli>.ts` implementing HookProvider.
  *      (File-based and stream-based provider types will land when the first such
  *       provider ships.)
- *   2. Add an export line below.
+ *   2. Add an export line below, and append the provider to `hookProviders`.
  *
  * The adapter (VS Code extension, standalone CLI, etc.) imports from here rather
  * than reaching into each provider directory directly.
@@ -13,14 +13,16 @@
 
 import type { HookProvider } from '../../../core/src/provider.js';
 import { claudeProvider } from './hook/claude/claude.js';
+import { opencodeProvider } from './hook/opencode/opencode.js';
 
-export { claudeProvider };
+export { claudeProvider, opencodeProvider };
 export { copyHookScript } from './hook/claude/claudeHookInstaller.js';
+export { installBridgePlugin } from './hook/opencode/opencodeBridgeInstaller.js';
 
 /** Every bundled hook provider, in registration order. The consent gate loops
  *  over this at the webviewReady handshake (one ask per provider that needs
  *  one) and `hooksConsentResponse` resolves its provider id against it. */
-export const hookProviders: readonly HookProvider[] = [claudeProvider];
+export const hookProviders: readonly HookProvider[] = [claudeProvider, opencodeProvider];
 
 /** Resolve a wire-supplied provider id, or undefined for an unknown one —
  *  the caller writes nothing on undefined (fail-closed, like a junk choice). */


### PR DESCRIPTION
OpenCode sessions appear in the office as hooks-only external agents, alongside Claude Code. First real second provider behind the HookProvider boundary.

## What changed and why

**New provider (`server/src/providers/hook/opencode/`, one subdirectory per the registry contract):**
- `opencode.ts` — normalizes the bridge envelope vocabulary into `AgentEvent`, OpenCode tool status text (reuses Claude status prefixes so animations work with no webview change), tool sets, `buildLaunchCommand`. Hooks-only: OpenCode persists sessions in SQLite (`~/.local/share/opencode/opencode.db`), not JSONL, so there is deliberately no file fallback and no team extension in the MVP.
- `bridge/pixel-agents-bridge.ts` — self-contained OpenCode plugin (zero repo imports, runs under Bun). Maps bus events (`session.created/deleted/idle`, `tool.execute.before/after`, `permission.asked` + `permission.ask` alias) to hook envelopes and fan-out POSTs to every live server in `~/.pixel-agents/servers/` (same discovery protocol as `claude-hook.js`).
- `opencodeBridgeInstaller.ts` — owns exactly one file (`~/.config/opencode/plugins/pixel-agents.ts`). Marker-based identity (foreign files abort, never overwritten), no backup (only our own marker content is ever replaced), atomic tmp+rename.
- `constants.ts`, `consentCopy.ts` — first-run disclosure naming the plugin file, local-only data flow, and Settings undo.

**Runtime (multi-provider dispatch, see `docs/adr/0002-per-event-provider-resolution.md`):**
- `hookEventHandler.ts` — resolves the provider per wire event (unknown ids fall back to the constructor provider); subagent gates and the Task/Agent overlay suppression are provider-driven instead of name literals. Every Claude path is byte-for-byte identical (sentinel `'current'` never matches a real id; Claude's subagent set is exactly {`Task`,`Agent`}).
- `agentRuntime.ts` — passes the registry resolver; file fallback / terminal adoption / singletons stay on Claude.
- `cli.ts` + `PixelAgentsViewProvider.ts` — per-provider bridge/script copy step before install.
- `providerCapabilities` now sends the union over all registered providers (tool names are case-namespaced per provider).
- `esbuild.js` copies the bridge verbatim to `dist/bridge/`; pinned in `package.json` files, npm-package-contract, and vsix verify lists.

## How tested
- `npm run check-types`, `npm run lint` (0 errors), `npm test` (webview 86 + server 590 + contract 7, all pass), `asyncapi:generate` + `e2e:inventory` drift checks clean, `npm run build` green.
- New suites: `opencode.test.ts` (normalize/status/consent), `opencodeBridgeInstaller.test.ts` (copy/idempotent/foreign-refusal/uninstall), `opencodeHookDispatch.test.ts` (per-event resolution, hook-parented subagent lifecycle, Claude fallback unchanged).
- `consentFlow.test.ts`: three assertions scoped to `providerId: 'claude'` — with two registered providers the gate correctly still asks for the unanswered one ("one ask per provider" contract).
- Live proof against the built standalone server: curl envelope sequence AND the actual shipped bridge file produced the full lifecycle on the wire — `agentCreated` (hooksOnly) → `agentToolStart` (stable `hook-<callId>`) → subagent start/clear → permission bubble → waiting → `agentClosed`.
- e2e (Playwright) not run locally — no UI/adapter behavior changes for existing flows; leaving it to CI. No screenshots (no visual changes).