### PR TITLE
feat: optional area_label session tag for explicit room routing

### DIFF
--- a/adapters/vscode/PixelAgentsViewProvider.ts
+++ b/adapters/vscode/PixelAgentsViewProvider.ts
@@ -125,6 +125,7 @@ export class PixelAgentsViewProvider implements vscode.WebviewViewProvider {
         type: 'agentCreated',
         id,
         folderName: agent.folderName,
+        areaLabel: agent.areaLabel,
         isExternal: agent.isExternal || undefined,
         isTeammate: agent.leadAgentId !== undefined || undefined,
         teammateName: agent.agentName,

--- a/adapters/vscode/agentManager.ts
+++ b/adapters/vscode/agentManager.ts
@@ -287,6 +287,7 @@ export function persistAgents(agents: AgentStateStore, adapter: StateAdapter): v
       jsonlFile: agent.jsonlFile,
       projectDir: agent.projectDir,
       folderName: agent.folderName,
+      areaLabel: agent.areaLabel,
       teamName: agent.teamName,
       agentName: agent.agentName,
       isTeamLead: agent.isTeamLead,
@@ -381,6 +382,7 @@ export function restoreAgents(
       linesProcessed: 0,
       seenUnknownRecordTypes: new Set(),
       folderName: p.folderName,
+      areaLabel: p.areaLabel,
       hookDelivered: false,
       contextTokens: 0,
       maxContextTokens: DEFAULT_MAX_CONTEXT_TOKENS,
@@ -537,12 +539,16 @@ export function sendExistingAgents(
   // Include persisted palette/seatId from separate key
   const agentMeta = adapter.loadSeats();
 
-  // Include folderName and isExternal per agent
+  // Include folderName, areaLabel and isExternal per agent
   const folderNames: Record<number, string> = {};
+  const areaLabels: Record<number, string> = {};
   const externalAgents: Record<number, boolean> = {};
   for (const [id, agent] of agents) {
     if (agent.folderName) {
       folderNames[id] = agent.folderName;
+    }
+    if (agent.areaLabel) {
+      areaLabels[id] = agent.areaLabel;
     }
     if (agent.isExternal) {
       externalAgents[id] = true;
@@ -557,6 +563,7 @@ export function sendExistingAgents(
     agents: agentIds,
     agentMeta,
     folderNames,
+    areaLabels,
     externalAgents,
   });
   // Note: sendCurrentAgentStatuses is called separately AFTER layoutLoaded

--- a/core/asyncapi.yaml
+++ b/core/asyncapi.yaml
@@ -182,6 +182,12 @@ components:
           type: integer
         folderName:
           type: string
+        areaLabel:
+          type: string
+          description: |
+            Explicit Area label from PIXEL_AGENTS_AREA env var. When present, the
+            agent character is seated in this named Area instead of resolving via
+            the folderName→areaMappings path.
         isExternal:
           type: boolean
         palette:
@@ -235,6 +241,13 @@ components:
         folderNames:
           type: object
           description: Map of agent ID (string) to workspace folder name.
+          additionalProperties:
+            type: string
+        areaLabels:
+          type: object
+          description: |
+            Map of agent ID (string) to explicit Area label (from PIXEL_AGENTS_AREA).
+            Only present for agents that have an area label set.
           additionalProperties:
             type: string
         externalAgents:

--- a/core/src/messages.ts
+++ b/core/src/messages.ts
@@ -74,6 +74,7 @@ export interface AgentCreated {
   type: 'agentCreated';
   id: number;
   folderName?: string;
+  areaLabel?: string;
   isExternal?: boolean;
   palette?: number;
   hueShift?: number;
@@ -94,6 +95,7 @@ export interface ExistingAgents {
   agents: number[];
   agentMeta: Record<string, AgentSeatMeta>;
   folderNames: Record<string, string>;
+  areaLabels?: Record<string, string>;
   externalAgents: Record<string, boolean>;
 }
 

--- a/core/src/provider.ts
+++ b/core/src/provider.ts
@@ -59,6 +59,11 @@ export type AgentEvent =
       /** Working directory the session was started in. Used to match pending
        *  external sessions against known workspace folders. */
       cwd?: string;
+      /** Explicit Area label for this session. When set, the agent character is
+       *  seated in this named Area regardless of the folderName→areaMappings
+       *  lookup. Sourced from the PIXEL_AGENTS_AREA env var on the agent process
+       *  and injected by the hook script into the SessionStart payload. */
+      areaLabel?: string;
     }
   | { kind: 'sessionEnd'; reason?: string };
 

--- a/core/src/schemas.ts
+++ b/core/src/schemas.ts
@@ -20,6 +20,9 @@ export interface PersistedAgent {
   jsonlFile: string;
   projectDir: string;
   folderName?: string;
+  /** Explicit Area label from PIXEL_AGENTS_AREA env var. Persisted so the agent
+   *  returns to the same Area after a server restart. */
+  areaLabel?: string;
   teamName?: string;
   agentName?: string;
   isTeamLead?: boolean;

--- a/server/__tests__/claude.test.ts
+++ b/server/__tests__/claude.test.ts
@@ -187,6 +187,34 @@ describe('claudeProvider', () => {
         expect(result.event.source).toBe('startup');
         expect(result.event.transcriptPath).toBe('/Users/x/.claude/projects/foo/sess-1.jsonl');
         expect(result.event.cwd).toBe('/Users/x/work');
+        expect(result.event.areaLabel).toBeUndefined();
+      }
+    });
+
+    it('normalizes SessionStart with area_label from PIXEL_AGENTS_AREA hook injection', () => {
+      const result = claudeProvider.normalizeHookEvent({
+        hook_event_name: 'SessionStart',
+        session_id: 'sess-2',
+        source: 'startup',
+        transcript_path: '/Users/x/.claude/projects/foo/sess-2.jsonl',
+        cwd: '/Users/x/work',
+        area_label: 'research',
+      });
+      expect(result?.event.kind).toBe('sessionStart');
+      if (result?.event.kind === 'sessionStart') {
+        expect(result.event.areaLabel).toBe('research');
+      }
+    });
+
+    it('ignores empty area_label in SessionStart', () => {
+      const result = claudeProvider.normalizeHookEvent({
+        hook_event_name: 'SessionStart',
+        session_id: 'sess-3',
+        area_label: '',
+      });
+      expect(result?.event.kind).toBe('sessionStart');
+      if (result?.event.kind === 'sessionStart') {
+        expect(result.event.areaLabel).toBeUndefined();
       }
     });
 

--- a/server/__tests__/hookEventHandler.test.ts
+++ b/server/__tests__/hookEventHandler.test.ts
@@ -576,10 +576,43 @@ describe('HookEventHandler', () => {
       'ext-sess',
       '/projects/test/ext-sess.jsonl',
       '/projects/test',
+      undefined,
     );
     // Stop was re-processed after agent creation
     const agent = agents.get(2);
     expect(agent?.isWaiting).toBe(true);
+  });
+
+  it('SessionStart with area_label threads areaLabel to onExternalSessionDetected', () => {
+    const onExternalSessionDetected = vi.fn();
+    handler.setLifecycleCallbacks({ onExternalSessionDetected });
+
+    onExternalSessionDetected.mockImplementation((sessionId: string) => {
+      const agent = createTestAgent({ id: 2, sessionId, projectDir: '/projects/test' });
+      agents.set(2, agent);
+      handler.registerAgent(sessionId, 2);
+    });
+
+    handler.handleEvent('claude', {
+      hook_event_name: 'SessionStart',
+      session_id: 'area-sess',
+      transcript_path: '/projects/test/area-sess.jsonl',
+      cwd: '/projects/test',
+      area_label: 'research',
+    });
+
+    // Not created yet — confirm with Stop
+    handler.handleEvent('claude', {
+      hook_event_name: 'Stop',
+      session_id: 'area-sess',
+    });
+
+    expect(onExternalSessionDetected).toHaveBeenCalledWith(
+      'area-sess',
+      '/projects/test/area-sess.jsonl',
+      '/projects/test',
+      'research',
+    );
   });
 
   // ── Resume ──────────────────────────────────────────────────
@@ -721,6 +754,7 @@ describe('HookEventHandler', () => {
       'no-transcript-sess',
       undefined,
       '/projects/test',
+      undefined,
     );
   });
 

--- a/server/src/agentRuntime.ts
+++ b/server/src/agentRuntime.ts
@@ -153,7 +153,7 @@ export class AgentRuntime {
 
     // Wire hook lifecycle callbacks to shared agent operations
     this.hookEventHandler.setLifecycleCallbacks({
-      onExternalSessionDetected: (sessionId, transcriptPath, cwd) => {
+      onExternalSessionDetected: (sessionId, transcriptPath, cwd, areaLabel) => {
         const projectDir = transcriptPath ? path.dirname(transcriptPath) : cwd;
         // Teammate session of a tracked lead? Attach it as a teammate character
         // instead of adopting a generic external agent -- and regardless of the
@@ -212,6 +212,7 @@ export class AgentRuntime {
           this.permissionTimers,
           () => this.store.persist(),
           (agent) => this.registerAgent(agent.sessionId, agent.id),
+          areaLabel,
         );
       },
       onSessionClear: (agentId, newSessionId, newTranscriptPath) => {

--- a/server/src/agentStateStore.ts
+++ b/server/src/agentStateStore.ts
@@ -164,6 +164,7 @@ export class AgentStateStore {
         jsonlFile: agent.jsonlFile,
         projectDir: agent.projectDir,
         folderName: agent.folderName,
+        areaLabel: agent.areaLabel,
         teamName: agent.teamName,
         agentName: agent.agentName,
         isTeamLead: agent.isTeamLead,

--- a/server/src/fileWatcher.ts
+++ b/server/src/fileWatcher.ts
@@ -1070,6 +1070,7 @@ export function adoptExternalSessionFromHook(
 
   persistAgents: () => void,
   onAgentCreated?: (agent: AgentState) => void,
+  areaLabel?: string,
 ): void {
   if (transcriptPath) {
     // File-based provider (Claude, Codex): adopt with JSONL file watching
@@ -1099,6 +1100,7 @@ export function adoptExternalSessionFromHook(
       permissionTimers,
       persistAgents,
       folderName,
+      areaLabel,
     );
 
     const adoptedAgent = [...agents.values()].find((a) => pathsMatch(a.jsonlFile, transcriptPath));
@@ -1140,6 +1142,7 @@ export function adoptExternalSessionFromHook(
       linesProcessed: 0,
       seenUnknownRecordTypes: new Set(),
       folderName,
+      areaLabel,
       contextTokens: 0,
       maxContextTokens: DEFAULT_MAX_CONTEXT_TOKENS,
     };
@@ -1167,6 +1170,7 @@ function adoptExternalSession(
 
   persistAgents: () => void,
   folderName?: string,
+  areaLabel?: string,
 ): void {
   const id = nextAgentIdRef.current++;
   // Decide whether to replay the existing file content or skip to its end.
@@ -1221,6 +1225,7 @@ function adoptExternalSession(
     linesProcessed: 0,
     seenUnknownRecordTypes: new Set(),
     folderName,
+    areaLabel,
     contextTokens: 0,
     maxContextTokens: DEFAULT_MAX_CONTEXT_TOKENS,
   };

--- a/server/src/hookEventHandler.ts
+++ b/server/src/hookEventHandler.ts
@@ -32,11 +32,13 @@ export interface HookEvent {
 /** Callback for session lifecycle events detected via hooks. */
 interface SessionLifecycleCallbacks {
   /** Called when an external session is detected (unknown session_id in SessionStart).
-   *  transcriptPath is undefined for providers without transcripts (OpenCode, Copilot). */
+   *  transcriptPath is undefined for providers without transcripts (OpenCode, Copilot).
+   *  areaLabel is the optional PIXEL_AGENTS_AREA override from the agent process. */
   onExternalSessionDetected?: (
     sessionId: string,
     transcriptPath: string | undefined,
     cwd: string,
+    areaLabel?: string,
   ) => void;
   /** Called when /clear is detected via hooks (SessionEnd reason=clear + SessionStart source=clear). */
   onSessionClear?: (
@@ -243,6 +245,7 @@ export class HookEventHandler {
           sessionId: event.session_id,
           transcriptPath,
           cwd: cwd ?? '',
+          areaLabel: normEvent.areaLabel,
         });
       } else {
         if (debug && tracked)
@@ -275,6 +278,7 @@ export class HookEventHandler {
         pending.sessionId,
         pending.transcriptPath,
         pending.cwd,
+        pending.areaLabel,
       );
       // Re-process this event now that the agent exists
       this.handleEvent(_providerId, event);

--- a/server/src/httpServer.ts
+++ b/server/src/httpServer.ts
@@ -174,6 +174,7 @@ function registerWebSocketRoute(app: FastifyInstance, options: HttpServerOptions
         type: 'agentCreated',
         id,
         folderName: agent.folderName,
+        areaLabel: agent.areaLabel,
         isExternal: agent.isExternal || undefined,
         isTeammate: agent.leadAgentId !== undefined || undefined,
         teammateName: agent.agentName,

--- a/server/src/providers/hook/claude/claude.ts
+++ b/server/src/providers/hook/claude/claude.ts
@@ -212,6 +212,8 @@ function normalizeHookEvent(
           source: typeof raw.source === 'string' ? raw.source : undefined,
           transcriptPath: typeof raw.transcript_path === 'string' ? raw.transcript_path : undefined,
           cwd: typeof raw.cwd === 'string' ? raw.cwd : undefined,
+          areaLabel:
+            typeof raw.area_label === 'string' && raw.area_label ? raw.area_label : undefined,
         },
       };
 

--- a/server/src/providers/hook/claude/hooks/claude-hook.ts
+++ b/server/src/providers/hook/claude/hooks/claude-hook.ts
@@ -163,6 +163,14 @@ async function main(): Promise<void> {
   const eventName = (data.hook_event_name as string | undefined) ?? '?';
   const sid = (data.session_id as string | undefined)?.slice(0, 8) ?? '?';
 
+  // For SessionStart events, propagate the PIXEL_AGENTS_AREA env var so that
+  // external orchestrators can seat agents in a named Area without relying on
+  // the workspace-folder mapping.
+  const areaLabel = process.env['PIXEL_AGENTS_AREA'];
+  if (eventName === 'SessionStart' && areaLabel) {
+    data = { ...data, area_label: areaLabel };
+  }
+
   // Multi-server fan-out (D4): deliver to every live server in the registry.
   // Falls back to the single legacy server.json when the registry has no live
   // entries -- e.g. a server on disk that predates the registry (A1/A2).

--- a/server/src/sessionRouter.ts
+++ b/server/src/sessionRouter.ts
@@ -6,6 +6,10 @@ export interface PendingExternalSession {
   /** Transcript file path. Undefined for providers without transcripts (OpenCode, Copilot). */
   transcriptPath: string | undefined;
   cwd: string;
+  /** Explicit Area label from the PIXEL_AGENTS_AREA env var on the agent process.
+   *  When present, the agent is seated in this named Area instead of resolving
+   *  the area via the folderName→areaMappings path. */
+  areaLabel?: string;
 }
 
 /** An event waiting to be dispatched once its agent registers. */

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -22,6 +22,10 @@ export interface AgentState {
   hadToolsInTurn: boolean;
   /** Workspace folder name (only set for multi-root workspaces) */
   folderName?: string;
+  /** Explicit Area label from PIXEL_AGENTS_AREA env var on the agent process.
+   *  When set, the agent character is seated in this named Area instead of
+   *  resolving via the folderName→areaMappings path. */
+  areaLabel?: string;
   /** Timestamp of last JSONL data received (ms since epoch) */
   lastDataAt: number;
   /** Total JSONL lines processed for this agent */
@@ -98,6 +102,9 @@ export interface PersistedAgent {
   projectDir: string;
   /** Workspace folder name (only set for multi-root workspaces) */
   folderName?: string;
+  /** Explicit Area label from PIXEL_AGENTS_AREA env var. Persisted so the agent
+   *  returns to the same Area after a server restart. */
+  areaLabel?: string;
 
   // -- Agent Teams --
   teamName?: string;

--- a/webview-ui/src/hooks/useExtensionMessages.ts
+++ b/webview-ui/src/hooks/useExtensionMessages.ts
@@ -232,7 +232,16 @@ export function useExtensionMessages(
         }
         // Add buffered agents now that layout (and seats) are correct
         for (const p of pendingAgents) {
-          os.addAgent(p.id, p.palette, p.hueShift, p.seatId, true, p.folderName);
+          os.addAgent(
+            p.id,
+            p.palette,
+            p.hueShift,
+            p.seatId,
+            true,
+            p.folderName,
+            undefined,
+            p.areaLabel,
+          );
           if (p.isHeadless) os.setHeadless(p.id, true);
         }
         pendingAgents = [];
@@ -247,6 +256,7 @@ export function useExtensionMessages(
       } else if (msg.type === 'agentCreated') {
         const id = msg.id as number;
         const folderName = msg.folderName as string | undefined;
+        const areaLabel = msg.areaLabel as string | undefined;
         const isTeammate = msg.isTeammate as boolean | undefined;
         const teammateName = msg.teammateName as string | undefined;
         const teammateParentId = msg.parentAgentId as number | undefined;
@@ -283,7 +293,16 @@ export function useExtensionMessages(
         } else {
           const palette = msg.palette as number | undefined;
           const hueShift = msg.hueShift as number | undefined;
-          os.addAgent(id, palette, hueShift, undefined, undefined, folderName);
+          os.addAgent(
+            id,
+            palette,
+            hueShift,
+            undefined,
+            undefined,
+            folderName,
+            undefined,
+            areaLabel,
+          );
           noteFolderName(folderName);
           if (isHeadlessAgent(msg.isExternal as boolean | undefined)) {
             os.setHeadless(id, true);
@@ -321,6 +340,7 @@ export function useExtensionMessages(
         const incoming = msg.agents as number[];
         const meta = (msg.agentMeta || {}) as Record<number, ExistingAgentMeta>;
         const folderNames = (msg.folderNames || {}) as Record<number, string>;
+        const areaLabels = (msg.areaLabels || {}) as Record<number, string>;
         const externalAgents = (msg.externalAgents || {}) as Record<number, boolean>;
         const headlessAgents: Record<number, boolean> = {};
         for (const id of incoming) {
@@ -340,6 +360,7 @@ export function useExtensionMessages(
             layoutReadyRef.current,
             pendingAgents,
             headlessAgents,
+            areaLabels,
           )
         ) {
           saveAgentSeats(os);

--- a/webview-ui/src/office/engine/existingAgents.ts
+++ b/webview-ui/src/office/engine/existingAgents.ts
@@ -25,6 +25,9 @@ export interface PendingAgent {
   hueShift?: number;
   seatId?: string;
   folderName?: string;
+  /** Explicit Area label from PIXEL_AGENTS_AREA env var. When set, overrides
+   *  the folderName→areaMappings seat selection. */
+  areaLabel?: string;
   isHeadless?: boolean;
 }
 
@@ -38,6 +41,8 @@ export interface ExistingAgentsOffice {
     preferredSeatId?: string,
     skipSpawnEffect?: boolean,
     folderName?: string,
+    nearAgentId?: number,
+    areaLabel?: string,
   ) => void;
   setHeadless: (id: number, headless: boolean) => void;
 }
@@ -57,6 +62,7 @@ export function reconcileExistingAgents(
   layoutReady: boolean,
   pending: PendingAgent[],
   headlessAgents: Record<number, boolean> = {},
+  areaLabels: Record<number, string> = {},
 ): boolean {
   let addedDirectly = false;
   for (const id of incoming) {
@@ -67,11 +73,21 @@ export function reconcileExistingAgents(
       hueShift: m?.hueShift,
       seatId: m?.seatId,
       folderName: folderNames[id],
+      areaLabel: areaLabels[id],
       isHeadless: headlessAgents[id] === true,
     };
     if (layoutReady) {
       if (!os.characters.has(p.id)) {
-        os.addAgent(p.id, p.palette, p.hueShift, p.seatId, true, p.folderName);
+        os.addAgent(
+          p.id,
+          p.palette,
+          p.hueShift,
+          p.seatId,
+          true,
+          p.folderName,
+          undefined,
+          p.areaLabel,
+        );
         if (p.isHeadless) os.setHeadless(p.id, true);
         addedDirectly = true;
       }

--- a/webview-ui/src/office/engine/officeState.ts
+++ b/webview-ui/src/office/engine/officeState.ts
@@ -179,7 +179,7 @@ export class OfficeState {
     // Second pass: assign remaining characters to free seats
     for (const ch of this.characters.values()) {
       if (ch.seatId) continue;
-      const seatId = this.findFreeSeat(ch.folderName);
+      const seatId = this.findFreeSeat(ch.folderName, ch.areaLabel);
       if (seatId) {
         this.seats.get(seatId)!.assigned = true;
         ch.seatId = seatId;
@@ -346,18 +346,21 @@ export class OfficeState {
   /**
    * 3-stage seat picker for top-level agents.
    *
-   *   Stage 1: If `folderName` is given and `areaMappings[folderName]` lists
-   *            Area labels, prefer free seats whose tile is labeled with one
-   *            of those areas.
+   *   Stage 1: If `areaLabel` is given directly, use it as the target Area
+   *            (bypasses the folderName→areaMappings lookup entirely).
+   *            Otherwise, if `folderName` is given and `areaMappings[folderName]`
+   *            lists Area labels, prefer free seats whose tile is labeled with
+   *            one of those areas.
    *   Stage 2: Prefer free seats whose tile has NO area label (unzoned).
    *   Stage 3: Any free seat.
    *
    * Each stage routes through `pickFromSeats` for the PC-bias rule. Returns
-   * null only when every seat is already occupied. Passing `undefined`
-   * preserves pre-Areas single-stage behavior (skips Stage 1; Stage 2 picks
-   * unzoned seats from a layout without `areaTiles`, which is every seat).
+   * null only when every seat is already occupied. Passing `undefined` for
+   * both args preserves pre-Areas single-stage behavior (skips Stage 1;
+   * Stage 2 picks unzoned seats from a layout without `areaTiles`, which is
+   * every seat).
    */
-  private findFreeSeat(folderName?: string): string | null {
+  private findFreeSeat(folderName?: string, areaLabel?: string): string | null {
     const electronicsTiles = this.buildElectronicsTileSet();
     const freeSeats: string[] = [];
     for (const [uid, seat] of this.seats) {
@@ -365,7 +368,14 @@ export class OfficeState {
     }
     if (freeSeats.length === 0) return null;
 
-    const areaLabels = folderName ? this.areaMappings[folderName] : undefined;
+    // areaLabel wins over the folderName→areaMappings lookup when set.
+    const resolvedAreaLabels: string[] | undefined = areaLabel
+      ? [areaLabel]
+      : folderName
+        ? this.areaMappings[folderName]
+        : undefined;
+    // Keep using the local `areaLabels` name for Stage 1 to avoid changing the rest.
+    const areaLabels = resolvedAreaLabels;
 
     // Stage 1 — in-area seats for the folder's mapped Area labels.
     if (areaLabels && areaLabels.length > 0) {
@@ -430,6 +440,7 @@ export class OfficeState {
     skipSpawnEffect?: boolean,
     folderName?: string,
     nearAgentId?: number,
+    areaLabel?: string,
   ): void {
     if (this.characters.has(id)) return;
 
@@ -461,7 +472,7 @@ export class OfficeState {
       seatId = closestFreeSeat(this.seats, anchorAt.col, anchorAt.row);
     }
     if (!seatId) {
-      seatId = this.findFreeSeat(folderName);
+      seatId = this.findFreeSeat(folderName, areaLabel);
     }
 
     let ch: Character;
@@ -487,6 +498,9 @@ export class OfficeState {
 
     if (folderName) {
       ch.folderName = folderName;
+    }
+    if (areaLabel) {
+      ch.areaLabel = areaLabel;
     }
     if (!skipSpawnEffect) {
       startMatrixEffect(ch, 'spawn');

--- a/webview-ui/src/office/types.ts
+++ b/webview-ui/src/office/types.ts
@@ -223,6 +223,10 @@ export interface Character {
   matrixEffectSeeds: number[];
   /** Workspace folder name (only set for multi-root workspaces) */
   folderName?: string;
+  /** Explicit Area label from PIXEL_AGENTS_AREA env var on the agent process.
+   *  When set, the character was seated in this named Area at creation and will
+   *  be re-seated there on layout rebuilds. */
+  areaLabel?: string;
   /** Headless agent: adopted from outside the office, so there is no terminal to
    *  focus. Rendered translucent. Teammates and sub-agents are never headless —
    *  clicking them reaches their lead's / parent's terminal. */

--- a/webview-ui/test/existingAgents.test.ts
+++ b/webview-ui/test/existingAgents.test.ts
@@ -34,6 +34,8 @@ interface AddAgentCall {
   seatId?: string;
   skipSpawnEffect?: boolean;
   folderName?: string;
+  nearAgentId?: number;
+  areaLabel?: string;
 }
 
 /** A fake office that records addAgent calls, mirroring how officeCanvasCursor
@@ -48,9 +50,27 @@ function fakeOffice(
     calls,
     headless,
     characters: { has: (id: number) => ids.has(id) },
-    addAgent: (id, palette, hueShift, seatId, skipSpawnEffect, folderName) => {
+    addAgent: (
+      id,
+      palette,
+      hueShift,
+      seatId,
+      skipSpawnEffect,
+      folderName,
+      nearAgentId,
+      areaLabel,
+    ) => {
       ids.add(id);
-      calls.push({ id, palette, hueShift, seatId, skipSpawnEffect, folderName });
+      calls.push({
+        id,
+        palette,
+        hueShift,
+        seatId,
+        skipSpawnEffect,
+        folderName,
+        nearAgentId,
+        areaLabel,
+      });
     },
     setHeadless: (id, isHeadless) => {
       if (isHeadless) headless.push(id);
@@ -81,6 +101,8 @@ test('layout ready: adds restored agents immediately with their seat metadata', 
       seatId: 'seat-a',
       skipSpawnEffect: true,
       folderName: 'alpha',
+      nearAgentId: undefined,
+      areaLabel: undefined,
     },
   ]);
 });
@@ -100,7 +122,15 @@ test('layout not ready: buffers restored agents for the later layoutLoaded flush
   assert.equal(addedDirectly, false);
   assert.equal(os.calls.length, 0, 'no agent should be added before the layout is ready');
   assert.deepEqual(pending, [
-    { id: 5, palette: 2, hueShift: 90, seatId: 'seat-a', folderName: 'alpha', isHeadless: false },
+    {
+      id: 5,
+      palette: 2,
+      hueShift: 90,
+      seatId: 'seat-a',
+      folderName: 'alpha',
+      areaLabel: undefined,
+      isHeadless: false,
+    },
   ]);
 });
 
@@ -174,6 +204,63 @@ test('layout ready: agent with no metadata is still added with undefined fields'
       seatId: undefined,
       skipSpawnEffect: true,
       folderName: undefined,
+      nearAgentId: undefined,
+      areaLabel: undefined,
     },
   ]);
+});
+
+// ── areaLabel (PIXEL_AGENTS_AREA explicit area override) ────────
+
+test('layout ready: areaLabel is threaded through to addAgent', () => {
+  const os = fakeOffice();
+  const pending: PendingAgent[] = [];
+  const meta: Record<number, ExistingAgentMeta> = {
+    8: { palette: 1, hueShift: 0, seatId: undefined },
+  };
+  const folderNames: Record<number, string> = {};
+  const areaLabels: Record<number, string> = { 8: 'research' };
+
+  const addedDirectly = reconcileExistingAgents(
+    os,
+    [8],
+    meta,
+    folderNames,
+    true,
+    pending,
+    {},
+    areaLabels,
+  );
+
+  assert.equal(addedDirectly, true);
+  assert.deepEqual(os.calls, [
+    {
+      id: 8,
+      palette: 1,
+      hueShift: 0,
+      seatId: undefined,
+      skipSpawnEffect: true,
+      folderName: undefined,
+      nearAgentId: undefined,
+      areaLabel: 'research',
+    },
+  ]);
+});
+
+test('layout not ready: areaLabel rides along on the buffered agent', () => {
+  const os = fakeOffice();
+  const pending: PendingAgent[] = [];
+  const meta: Record<number, ExistingAgentMeta> = {
+    9: { palette: 0, hueShift: 0, seatId: undefined },
+  };
+  const folderNames: Record<number, string> = {};
+  const areaLabels: Record<number, string> = { 9: 'engineering' };
+
+  reconcileExistingAgents(os, [9], meta, folderNames, false, pending, {}, areaLabels);
+
+  assert.equal(os.calls.length, 0);
+  assert.deepEqual(
+    pending.map((p) => [p.id, p.areaLabel]),
+    [[9, 'engineering']],
+  );
 });


### PR DESCRIPTION
## What

Adds an optional `area_label` session tag so external orchestrators can route an agent's character to a specific Area (room) by name, instead of relying only on folder-name mappings.

- The Claude Code hook script forwards a `PIXEL_AGENTS_AREA` env var (when set) as `area_label` on the SessionStart event.
- `area_label` flows through `normalizeHookEvent` → `AgentEvent.sessionStart.areaLabel` → pending session → `AgentState`/`PersistedAgent`, and is exposed on `agentCreated` / `existingAgents` (asyncapi.yaml updated, `messages.ts` regenerated).
- `officeState.findFreeSeat` gains a stage-1 override: if the session carries an `area_label` matching an Area, seat there first; otherwise fall back to the existing folderName mapping and free-seat logic unchanged.

## Why

When one workspace folder hosts multiple concurrent agent groups (e.g. an orchestrator spawning task-scoped agents for different campaigns), folder-name routing puts them all in the same room. A per-session label lets the spawning process say which room each agent belongs in — purely opt-in, no behavior change when the env var is absent.

## Notes for review

- `areaLabels` map keys are coerced the same way as the existing `folderNames` handling (numeric/string key coercion follows that pattern).
- If a labeled Area has been deleted, seating falls back to `rebuildFromLayout`'s normal path — no crash, just default seating.
- `protocolVersion` is intentionally not bumped: the change is purely additive (new optional fields).
- While in there we noticed `persistAgents` in the standalone path appears to be dead code; left untouched to keep this PR minimal.

## Testing

- Full suite green (553 tests), lint, type-check, and build all pass.
- Manually verified with an external orchestrator setting `PIXEL_AGENTS_AREA` per spawned session: agents seat in the labeled room; unlabeled sessions behave exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
