### PR TITLE
feat(providers): add Codex as a second hook provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ It ships in two forms from the same codebase:
 - **VS Code extension** — [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=pablodelucca.pixel-agents) and [Open VSX](https://open-vsx.org/extension/pablodelucca/pixel-agents). Agents launch into VS Code terminals; characters render in the panel area.
 - **Standalone CLI** — `npx pixel-agents` starts a local server and serves the same office as a browser app, useful for tmux, remote, and non-VS Code workflows.
 
-The architecture is fully agent-agnostic and editor-agnostic: a typed `HookProvider` interface defines the integration boundary so adding a new AI tool is a single subdirectory of code. Claude Code is the reference implementation today; Codex, Gemini, Cursor, and others are on the roadmap.
+The architecture is fully agent-agnostic and editor-agnostic: a typed `HookProvider` interface defines the integration boundary so adding a new AI tool is a single subdirectory of code. Claude Code and Codex ship today (both hook-based); Gemini, Cursor, and others are on the roadmap.
 
 ![Pixel Agents screenshot](webview-ui/public/office.png)
 

--- a/core/src/provider.ts
+++ b/core/src/provider.ts
@@ -116,6 +116,17 @@ export interface HookProvider {
    *  previous estimate and widens it if a context ever exceeds it. */
   contextWindowForModel?(model: string | undefined): number | undefined;
 
+  /** Does this CLI appear to be installed for the current user?
+   *
+   *  Only consulted to decide whether to ASK for hook consent: asking someone
+   *  to let us edit the config of a tool they do not have is a prompt they
+   *  cannot evaluate and must answer just to dismiss. Absent = treated as
+   *  present, the right default for a provider that cannot tell cheaply.
+   *
+   *  Never gates event handling: a provider that reports false but then sends
+   *  events is still served, because the events prove it is there. */
+  isPresent?(): boolean;
+
   // ── Optional file fallback (heuristic mode) ──
 
   /** Session directories to scan. Undefined = no file fallback. */

--- a/esbuild.js
+++ b/esbuild.js
@@ -39,27 +39,31 @@ function copyAssets() {
  * Produces a self-contained CJS file with shebang for Claude Code to execute.
  */
 function buildHooks() {
-  const entry = path.join(
-    __dirname,
-    'server',
-    'src',
-    'providers',
-    'hook',
-    'claude',
-    'hooks',
-    'claude-hook.ts',
-  );
-  if (!fs.existsSync(entry)) return;
+  const hookEntry = (provider, file) =>
+    path.join(__dirname, 'server', 'src', 'providers', 'hook', provider, 'hooks', file);
+  // One entry per provider that installs a hook script. Each bundles to its own
+  // self-contained CJS file, so one provider's script never depends on another's.
+  const entries = [
+    hookEntry('claude', 'claude-hook.ts'),
+    hookEntry('codex', 'codex-hook.ts'),
+  ].filter((p) => fs.existsSync(p));
+  if (entries.length === 0) return;
   require('esbuild').buildSync({
-    entryPoints: [entry],
+    entryPoints: entries,
     bundle: true,
     platform: 'node',
     target: 'node18',
     format: 'cjs',
     outdir: path.join(__dirname, 'dist', 'hooks'),
+    // With more than one entry esbuild mirrors the shared source tree into
+    // outdir (dist/hooks/claude/hooks/claude-hook.js). Every consumer — the
+    // installers, the package contracts, an already-installed settings.json
+    // entry — expects them flat, so outbase pins each to its own basename.
+    outbase: path.join(__dirname, 'server', 'src', 'providers', 'hook'),
+    entryNames: '[name]',
     banner: { js: '#!/usr/bin/env node' },
   });
-  console.log('✓ Built hooks/ → dist/hooks/');
+  console.log(`✓ Built ${entries.length} hook script(s) → dist/hooks/`);
 }
 
 /**

--- a/knip.json
+++ b/knip.json
@@ -14,6 +14,7 @@
   "ignore": [
     "core/src/index.ts",
     "server/src/providers/hook/claude/hooks/claude-hook.ts",
+    "server/src/providers/hook/codex/hooks/codex-hook.ts",
     "webview-ui/src/office/components/index.ts",
     "webview-ui/src/office/editor/index.ts",
     "webview-ui/src/office/engine/index.ts",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "dist/cli.js",
     "dist/extension.js",
     "dist/hooks/claude-hook.js",
+    "dist/hooks/codex-hook.js",
     "dist/uninstall.js",
     "dist/assets/",
     "dist/webview/",

--- a/scripts/npm-package-contract.mjs
+++ b/scripts/npm-package-contract.mjs
@@ -20,6 +20,7 @@ export const REQUIRED_PACKAGE_FILES = [
   'dist/cli.js',
   'dist/extension.js',
   'dist/hooks/claude-hook.js',
+  'dist/hooks/codex-hook.js',
   'dist/webview/index.html',
   'icon.png',
   'package.json',

--- a/scripts/verify-vsix-package.mjs
+++ b/scripts/verify-vsix-package.mjs
@@ -13,6 +13,7 @@ const REQUIRED_FILES = [
   'extension/dist/extension.js',
   'extension/dist/cli.js',
   'extension/dist/hooks/claude-hook.js',
+  'extension/dist/hooks/codex-hook.js',
   'extension/dist/webview/index.html',
 ];
 const FORBIDDEN_PREFIXES = [

--- a/server/__tests__/codex.test.ts
+++ b/server/__tests__/codex.test.ts
@@ -1,0 +1,305 @@
+import { describe, expect, it } from 'vitest';
+
+import { codexProvider, formatToolStatus } from '../src/providers/hook/codex/codex.js';
+import { CODEX_HOOK_EVENTS } from '../src/providers/hook/codex/constants.js';
+
+describe('codexProvider', () => {
+  describe('identity', () => {
+    it('has kind "hook"', () => {
+      expect(codexProvider.kind).toBe('hook');
+    });
+    it('has id "codex"', () => {
+      expect(codexProvider.id).toBe('codex');
+    });
+    it('has a displayName', () => {
+      expect(codexProvider.displayName).toBe('Codex');
+    });
+    it('has protocolVersion 1', () => {
+      expect(codexProvider.protocolVersion).toBe(1);
+    });
+    it('has no TeamProvider (Codex has no Agent Teams equivalent)', () => {
+      expect(codexProvider.team).toBeUndefined();
+    });
+    it('classifies Codex read tools as reading, not typing', () => {
+      for (const tool of ['read_file', 'grep', 'file_search', 'list_dir', 'view_image']) {
+        expect(codexProvider.readingTools.has(tool)).toBe(true);
+      }
+      // The two write-side tools must NOT read as reading, or the office shows
+      // a character with a book while it edits files.
+      expect(codexProvider.readingTools.has('apply_patch')).toBe(false);
+      expect(codexProvider.readingTools.has('exec_command')).toBe(false);
+    });
+    it('exempts non-prompting tools from the permission timer', () => {
+      expect(codexProvider.permissionExemptTools.has('update_plan')).toBe(true);
+      expect(codexProvider.permissionExemptTools.has('read_file')).toBe(true);
+      // exec_command and apply_patch are exactly the tools that DO prompt.
+      expect(codexProvider.permissionExemptTools.has('exec_command')).toBe(false);
+      expect(codexProvider.permissionExemptTools.has('apply_patch')).toBe(false);
+    });
+    it('has an empty subagentToolNames (no Task-style tool exists)', () => {
+      expect(codexProvider.subagentToolNames.size).toBe(0);
+    });
+  });
+
+  describe('hook surface', () => {
+    it('installs only events the runtime consumes', () => {
+      expect([...CODEX_HOOK_EVENTS]).toEqual([
+        'SessionStart',
+        'SessionEnd',
+        'PreToolUse',
+        'PostToolUse',
+        'PermissionRequest',
+        'Stop',
+        'SubagentStart',
+        'SubagentStop',
+      ]);
+    });
+    it('does NOT install UserPromptSubmit — it would forward prompt text for nothing', () => {
+      expect([...CODEX_HOOK_EVENTS]).not.toContain('UserPromptSubmit');
+    });
+    it('does NOT install compaction or Interrupt events', () => {
+      for (const e of ['PreCompact', 'PostCompact', 'Interrupt']) {
+        expect([...CODEX_HOOK_EVENTS]).not.toContain(e);
+      }
+    });
+    it('every installed event normalizes or is deliberately ignored', () => {
+      // Guards against adding an event to the install list and forgetting to
+      // map it: an installed-but-unmapped event is silent scope.
+      const mapped = CODEX_HOOK_EVENTS.filter(
+        (e) =>
+          codexProvider.normalizeHookEvent({
+            hook_event_name: e,
+            session_id: 's1',
+            tool_name: 'exec_command',
+            tool_use_id: 't1',
+            agent_id: 'a1',
+          }) !== null,
+      );
+      expect(mapped.length).toBe(CODEX_HOOK_EVENTS.length);
+    });
+  });
+
+  describe('normalizeHookEvent', () => {
+    const ev = (raw: Record<string, unknown>) => codexProvider.normalizeHookEvent(raw);
+
+    it('returns null when hook_event_name is missing', () => {
+      expect(ev({ session_id: 'x' })).toBeNull();
+    });
+    it('returns null when session_id is missing', () => {
+      expect(ev({ hook_event_name: 'Stop' })).toBeNull();
+    });
+    it('returns null for an event we deliberately do not install', () => {
+      expect(ev({ hook_event_name: 'UserPromptSubmit', session_id: 's', prompt: 'hi' })).toBeNull();
+      expect(ev({ hook_event_name: 'PreCompact', session_id: 's' })).toBeNull();
+      expect(ev({ hook_event_name: 'Interrupt', session_id: 's' })).toBeNull();
+    });
+
+    it('maps SessionStart with source, cwd and transcript path', () => {
+      const r = ev({
+        hook_event_name: 'SessionStart',
+        session_id: 's1',
+        source: 'startup',
+        cwd: '/repo',
+        transcript_path: '/t.jsonl',
+      });
+      expect(r?.sessionId).toBe('s1');
+      expect(r?.event).toEqual({
+        kind: 'sessionStart',
+        source: 'startup',
+        transcriptPath: '/t.jsonl',
+        cwd: '/repo',
+      });
+    });
+
+    it('maps SessionEnd with its reason', () => {
+      const r = ev({ hook_event_name: 'SessionEnd', session_id: 's1', reason: 'other' });
+      expect(r?.event).toEqual({ kind: 'sessionEnd', reason: 'other' });
+    });
+
+    it('maps PreToolUse to toolStart carrying the real tool id', () => {
+      const r = ev({
+        hook_event_name: 'PreToolUse',
+        session_id: 's1',
+        tool_name: 'exec_command',
+        tool_use_id: 'call_42',
+        tool_input: { command: 'ls' },
+      });
+      expect(r?.event).toEqual({
+        kind: 'toolStart',
+        toolId: 'call_42',
+        toolName: 'exec_command',
+        input: { command: 'ls' },
+      });
+    });
+
+    it('returns null for PreToolUse without a tool name', () => {
+      expect(ev({ hook_event_name: 'PreToolUse', session_id: 's1' })).toBeNull();
+    });
+
+    it('maps PostToolUse to toolEnd using the real id, not a sentinel', () => {
+      // This is the concrete win over the Claude provider: Codex carries the id
+      // on both sides, so correlation does not depend on handler state.
+      const r = ev({
+        hook_event_name: 'PostToolUse',
+        session_id: 's1',
+        tool_use_id: 'call_42',
+      });
+      expect(r?.event).toEqual({ kind: 'toolEnd', toolId: 'call_42' });
+    });
+
+    it('falls back to the "current" sentinel when PostToolUse has no id', () => {
+      const r = ev({ hook_event_name: 'PostToolUse', session_id: 's1' });
+      expect(r?.event).toEqual({ kind: 'toolEnd', toolId: 'current' });
+    });
+
+    it('maps PermissionRequest to permissionRequest', () => {
+      const r = ev({ hook_event_name: 'PermissionRequest', session_id: 's1' });
+      expect(r?.event).toEqual({ kind: 'permissionRequest' });
+    });
+
+    it('maps Stop to turnEnd without claiming awaitingInput', () => {
+      // Codex has no idle_prompt equivalent, so inventing awaitingInput would
+      // mislabel a finished turn as "waiting for you".
+      const r = ev({ hook_event_name: 'Stop', session_id: 's1', stop_hook_active: false });
+      expect(r?.event).toEqual({ kind: 'turnEnd' });
+      expect((r?.event as { awaitingInput?: boolean }).awaitingInput).toBeUndefined();
+    });
+
+    it('maps SubagentStart/Stop using agent_id as the character id', () => {
+      const start = ev({
+        hook_event_name: 'SubagentStart',
+        session_id: 's1',
+        agent_id: 'ag1',
+        agent_type: 'reviewer',
+        tool_use_id: 'call_9',
+      });
+      expect(start?.event).toEqual({
+        kind: 'subagentStart',
+        parentToolId: 'call_9',
+        toolId: 'ag1',
+        toolName: 'reviewer',
+        input: undefined,
+      });
+
+      const stop = ev({
+        hook_event_name: 'SubagentStop',
+        session_id: 's1',
+        agent_id: 'ag1',
+        tool_use_id: 'call_9',
+      });
+      expect(stop?.event).toEqual({
+        kind: 'subagentEnd',
+        parentToolId: 'call_9',
+        toolId: 'ag1',
+      });
+    });
+
+    it('returns null for subagent events without an agent id', () => {
+      expect(ev({ hook_event_name: 'SubagentStart', session_id: 's1' })).toBeNull();
+      expect(ev({ hook_event_name: 'SubagentStop', session_id: 's1' })).toBeNull();
+    });
+
+    it('ignores a non-object tool_input rather than passing junk downstream', () => {
+      const r = ev({
+        hook_event_name: 'PreToolUse',
+        session_id: 's1',
+        tool_name: 'exec_command',
+        tool_input: 'not-an-object',
+      });
+      expect((r?.event as { input?: unknown }).input).toBeUndefined();
+    });
+  });
+
+  describe('formatToolStatus', () => {
+    it('renders a string command', () => {
+      expect(formatToolStatus('exec_command', { command: 'npm test' })).toBe('Running: npm test');
+    });
+    it('renders an argv-array command instead of [object Object]', () => {
+      expect(formatToolStatus('exec_command', { command: ['git', 'status'] })).toBe(
+        'Running: git status',
+      );
+    });
+    it('clips a long command', () => {
+      const s = formatToolStatus('exec_command', { command: 'x'.repeat(200) });
+      expect(s.length).toBeLessThan(60);
+      expect(s.endsWith('…')).toBe(true);
+    });
+    it('falls back when exec_command carries no command', () => {
+      expect(formatToolStatus('exec_command', {})).toBe('Running a command');
+    });
+    it('names the file from an apply_patch body', () => {
+      const patch = '*** Begin Patch\n*** Update File: src/deep/nested/app.ts\n@@\n-a\n+b\n';
+      expect(formatToolStatus('apply_patch', { patch })).toBe('Editing app.ts');
+    });
+    it('handles an apply_patch that adds a file', () => {
+      const patch = '*** Begin Patch\n*** Add File: pkg/new.ts\n+hello\n';
+      expect(formatToolStatus('apply_patch', { patch })).toBe('Editing new.ts');
+    });
+    it('falls back for apply_patch with an unparseable body', () => {
+      expect(formatToolStatus('apply_patch', { patch: 'garbage' })).toBe('Editing files');
+    });
+    it('renders the remaining Codex tools', () => {
+      expect(formatToolStatus('update_plan', {})).toBe('Updating the plan');
+      expect(formatToolStatus('grep', {})).toBe('Searching code');
+      expect(formatToolStatus('list_dir', {})).toBe('Listing files');
+      expect(formatToolStatus('view_image', {})).toBe('Looking at an image');
+      expect(formatToolStatus('request_user_input', {})).toBe('Waiting for your answer');
+      expect(formatToolStatus('write_stdin', {})).toBe('Typing into a command');
+    });
+    it('shows only the tool half of an MCP name', () => {
+      expect(formatToolStatus('lanhu__get_designs', {})).toBe('Using get_designs');
+      expect(formatToolStatus('server.fetch_page', {})).toBe('Using fetch_page');
+    });
+    it('handles a completely unknown tool', () => {
+      expect(formatToolStatus('brand_new_tool', {})).toBe('Using brand_new_tool');
+    });
+    it('never throws on a missing input', () => {
+      for (const t of ['exec_command', 'apply_patch', 'read_file', 'grep', 'zzz']) {
+        expect(() => formatToolStatus(t)).not.toThrow();
+      }
+    });
+  });
+
+  describe('contextWindowForModel', () => {
+    const w = (m: string | undefined) => codexProvider.contextWindowForModel?.(m);
+
+    it('returns the default window for gpt-5 / codex families', () => {
+      expect(w('gpt-5.1-codex-max')).toBe(272_000);
+      expect(w('gpt-5-codex')).toBe(272_000);
+    });
+    it('matches the longest pattern, so gpt-4.1 is not shadowed', () => {
+      expect(w('gpt-4.1-2026-01-01')).toBe(1_047_576);
+      expect(w('gpt-4o-mini')).toBe(128_000);
+    });
+    it('handles reasoning-model ids', () => {
+      expect(w('o3-pro')).toBe(200_000);
+      expect(w('o4-mini')).toBe(200_000);
+    });
+    it('returns undefined for an unknown model so the runtime keeps its estimate', () => {
+      expect(w('llama-9000')).toBeUndefined();
+      expect(w(undefined)).toBeUndefined();
+    });
+    it('is case-insensitive', () => {
+      expect(w('GPT-5-Codex')).toBe(272_000);
+    });
+  });
+
+  describe('buildLaunchCommand', () => {
+    it('launches the codex binary in the given cwd', () => {
+      const c = codexProvider.buildLaunchCommand?.('sid', '/repo');
+      expect(c?.command).toBe('codex');
+      expect(c?.env?.['PWD']).toBe('/repo');
+    });
+    it('does not pass a session id (Codex mints its own)', () => {
+      const c = codexProvider.buildLaunchCommand?.('sid', '/repo');
+      expect(c?.args ?? []).not.toContain('--session-id');
+      expect(c?.args ?? []).not.toContain('sid');
+    });
+    it('passes the bypass flag only when asked', () => {
+      expect(codexProvider.buildLaunchCommand?.('s', '/r')?.args).toEqual([]);
+      expect(
+        codexProvider.buildLaunchCommand?.('s', '/r', { bypassPermissions: true })?.args,
+      ).toEqual(['--dangerously-bypass-approvals-and-sandbox']);
+    });
+  });
+});

--- a/server/__tests__/codexHookInstaller.test.ts
+++ b/server/__tests__/codexHookInstaller.test.ts
@@ -1,0 +1,288 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  areHooksInstalled,
+  getCodexHooksPath,
+  installHooks,
+  isOurHookCommand,
+  uninstallHooks,
+} from '../src/providers/hook/codex/codexHookInstaller.js';
+import { CODEX_HOOK_EVENTS } from '../src/providers/hook/codex/constants.js';
+
+// Every test runs against a throwaway HOME so a failing test can never touch
+// the developer's real ~/.codex/hooks.json. `vi.spyOn` cannot redefine an ESM
+// namespace export, so the redirection goes through a module mock — the same
+// seam claudeHookInstaller.test.ts uses.
+let tmpHome: string;
+
+vi.mock('os', async () => {
+  const actual = await vi.importActual<typeof import('os')>('os');
+  return { ...actual, default: actual, homedir: () => tmpHome };
+});
+
+beforeEach(() => {
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'pa-codex-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpHome, { recursive: true, force: true });
+});
+
+function readFile(): Record<string, unknown> {
+  return JSON.parse(fs.readFileSync(getCodexHooksPath(), 'utf-8')) as Record<string, unknown>;
+}
+
+function writeFile(content: unknown): void {
+  const p = getCodexHooksPath();
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, JSON.stringify(content, null, 2));
+}
+
+/** A hook entry that is not ours, used to prove we never delete a stranger's. */
+const FOREIGN = {
+  hooks: [{ type: 'command', command: 'python3 /opt/someone-else/audit.py' }],
+};
+
+describe('codexHookInstaller', () => {
+  describe('install', () => {
+    it('creates hooks.json with an entry for every declared event', async () => {
+      await installHooks('http://127.0.0.1:1', 'tok');
+      const file = readFile();
+      const hooks = file['hooks'] as Record<string, unknown[]>;
+      for (const event of CODEX_HOOK_EVENTS) {
+        expect(hooks[event]).toHaveLength(1);
+      }
+      expect(Object.keys(hooks).sort()).toEqual([...CODEX_HOOK_EVENTS].sort());
+    });
+
+    it('installs handlers as async so the agent loop never waits on us', async () => {
+      await installHooks('u', 't');
+      const hooks = readFile()['hooks'] as Record<
+        string,
+        Array<{ hooks: Array<Record<string, unknown>> }>
+      >;
+      const handler = hooks['PreToolUse'][0].hooks[0];
+      expect(handler['async']).toBe(true);
+      expect(handler['type']).toBe('command');
+      expect(handler['timeout']).toBe(5);
+      expect(String(handler['command'])).toContain('codex-hook.js');
+    });
+
+    it('omits matcher so every tool is observed', async () => {
+      await installHooks('u', 't');
+      const hooks = readFile()['hooks'] as Record<string, Array<Record<string, unknown>>>;
+      expect(hooks['PreToolUse'][0]['matcher']).toBeUndefined();
+    });
+
+    it('is idempotent — installing twice leaves one entry per event', async () => {
+      await installHooks('u', 't');
+      await installHooks('u', 't');
+      const hooks = readFile()['hooks'] as Record<string, unknown[]>;
+      for (const event of CODEX_HOOK_EVENTS) {
+        expect(hooks[event]).toHaveLength(1);
+      }
+    });
+
+    it('preserves a foreign hook in an event we also install', async () => {
+      writeFile({ hooks: { PreToolUse: [FOREIGN] } });
+      await installHooks('u', 't');
+      const hooks = readFile()['hooks'] as Record<string, unknown[]>;
+      expect(hooks['PreToolUse']).toHaveLength(2);
+      expect(JSON.stringify(hooks['PreToolUse'][0])).toContain('audit.py');
+    });
+
+    it('preserves a foreign hook on an event we never install', async () => {
+      writeFile({ hooks: { UserPromptSubmit: [FOREIGN] } });
+      await installHooks('u', 't');
+      const hooks = readFile()['hooks'] as Record<string, unknown[]>;
+      expect(hooks['UserPromptSubmit']).toHaveLength(1);
+      expect(JSON.stringify(hooks['UserPromptSubmit'])).toContain('audit.py');
+    });
+
+    it('preserves unrelated top-level keys', async () => {
+      writeFile({ description: 'my workspace hooks', hooks: {} });
+      await installHooks('u', 't');
+      expect(readFile()['description']).toBe('my workspace hooks');
+    });
+
+    it('backs up a pre-existing file exactly once', async () => {
+      writeFile({ hooks: { PreToolUse: [FOREIGN] } });
+      const backup = getCodexHooksPath() + '.pixel-agents.backup';
+
+      await installHooks('u', 't');
+      expect(fs.existsSync(backup)).toBe(true);
+      const first = fs.readFileSync(backup, 'utf-8');
+      expect(first).toContain('audit.py');
+
+      // A second install must not overwrite the ORIGINAL backup with our own
+      // already-modified content, or the user loses their pristine copy.
+      await installHooks('u', 't');
+      expect(fs.readFileSync(backup, 'utf-8')).toBe(first);
+    });
+
+    it('writes no backup when there was no file to back up', async () => {
+      await installHooks('u', 't');
+      expect(fs.existsSync(getCodexHooksPath() + '.pixel-agents.backup')).toBe(false);
+    });
+
+    it('sweeps our entry off an event that is no longer in the install list', async () => {
+      // Simulate a legacy install that hooked an event we since dropped.
+      await installHooks('u', 't');
+      const file = readFile();
+      const hooks = file['hooks'] as Record<string, unknown[]>;
+      hooks['Interrupt'] = [...(hooks['PreToolUse'] as unknown[])];
+      writeFile(file);
+
+      await installHooks('u', 't');
+      expect((readFile()['hooks'] as Record<string, unknown>)['Interrupt']).toBeUndefined();
+    });
+
+    it('leaves no temp file behind', async () => {
+      await installHooks('u', 't');
+      const dir = path.dirname(getCodexHooksPath());
+      expect(fs.readdirSync(dir).filter((f) => f.includes('tmp'))).toEqual([]);
+    });
+
+    it('throws a clear message on malformed JSON rather than overwriting it', async () => {
+      const p = getCodexHooksPath();
+      fs.mkdirSync(path.dirname(p), { recursive: true });
+      fs.writeFileSync(p, '{ this is not json');
+      await expect(installHooks('u', 't')).rejects.toThrow(/parse/i);
+      // The user's file must survive the refusal.
+      expect(fs.readFileSync(p, 'utf-8')).toBe('{ this is not json');
+    });
+
+    it('throws when hooks is not an object', async () => {
+      writeFile({ hooks: ['nope'] });
+      await expect(installHooks('u', 't')).rejects.toThrow(/not an object/);
+    });
+
+    it('throws when a single event is not an array', async () => {
+      writeFile({ hooks: { PreToolUse: { bad: true } } });
+      await expect(installHooks('u', 't')).rejects.toThrow(/not an array/);
+    });
+
+    it('treats an empty file as absent', async () => {
+      const p = getCodexHooksPath();
+      fs.mkdirSync(path.dirname(p), { recursive: true });
+      fs.writeFileSync(p, '   \n');
+      await expect(installHooks('u', 't')).resolves.toBeUndefined();
+      expect(Object.keys(readFile()['hooks'] as object)).toHaveLength(CODEX_HOOK_EVENTS.length);
+    });
+  });
+
+  describe('areHooksInstalled', () => {
+    it('is false before install', async () => {
+      expect(await areHooksInstalled()).toBe(false);
+    });
+    it('is true after install', async () => {
+      await installHooks('u', 't');
+      expect(await areHooksInstalled()).toBe(true);
+    });
+    it('is false when only SOME events carry our hook', async () => {
+      await installHooks('u', 't');
+      const file = readFile();
+      delete (file['hooks'] as Record<string, unknown>)['Stop'];
+      writeFile(file);
+      expect(await areHooksInstalled()).toBe(false);
+    });
+    it('is false when the file is malformed', async () => {
+      const p = getCodexHooksPath();
+      fs.mkdirSync(path.dirname(p), { recursive: true });
+      fs.writeFileSync(p, 'not json');
+      expect(await areHooksInstalled()).toBe(false);
+    });
+    it('is false when only foreign hooks are present', async () => {
+      writeFile({ hooks: Object.fromEntries(CODEX_HOOK_EVENTS.map((e) => [e, [FOREIGN]])) });
+      expect(await areHooksInstalled()).toBe(false);
+    });
+  });
+
+  describe('uninstall', () => {
+    it('removes the file when it held only our hooks', async () => {
+      await installHooks('u', 't');
+      await uninstallHooks();
+      expect(fs.existsSync(getCodexHooksPath())).toBe(false);
+    });
+
+    it('keeps foreign hooks and drops only ours', async () => {
+      writeFile({ hooks: { PreToolUse: [FOREIGN] } });
+      await installHooks('u', 't');
+      await uninstallHooks();
+
+      const hooks = readFile()['hooks'] as Record<string, unknown[]>;
+      expect(hooks['PreToolUse']).toHaveLength(1);
+      expect(JSON.stringify(hooks['PreToolUse'])).toContain('audit.py');
+      expect(JSON.stringify(hooks)).not.toContain('codex-hook.js');
+    });
+
+    it('keeps the file when other top-level keys remain', async () => {
+      writeFile({ description: 'keep me' });
+      await installHooks('u', 't');
+      await uninstallHooks();
+      expect(fs.existsSync(getCodexHooksPath())).toBe(true);
+      expect(readFile()['description']).toBe('keep me');
+      expect(readFile()['hooks']).toBeUndefined();
+    });
+
+    it('strips our handler from a group we share with a stranger', async () => {
+      // A hand-merged group holding both commands: ours must go, theirs stay.
+      await installHooks('u', 't');
+      const file = readFile();
+      const hooks = file['hooks'] as Record<string, Array<{ hooks: unknown[] }>>;
+      hooks['PreToolUse'][0].hooks.push({
+        type: 'command',
+        command: 'python3 /opt/theirs.py',
+      });
+      writeFile(file);
+
+      await uninstallHooks();
+      const after = readFile()['hooks'] as Record<string, unknown[]>;
+      expect(JSON.stringify(after)).toContain('theirs.py');
+      expect(JSON.stringify(after)).not.toContain('codex-hook.js');
+    });
+
+    it('is a no-op when there is no file', async () => {
+      await expect(uninstallHooks()).resolves.toBeUndefined();
+    });
+
+    it('is idempotent', async () => {
+      await installHooks('u', 't');
+      await uninstallHooks();
+      await expect(uninstallHooks()).resolves.toBeUndefined();
+    });
+
+    it('leaves a malformed file alone rather than guessing', async () => {
+      const p = getCodexHooksPath();
+      fs.mkdirSync(path.dirname(p), { recursive: true });
+      fs.writeFileSync(p, 'not json');
+      await expect(uninstallHooks()).rejects.toThrow(/parse/i);
+      expect(fs.readFileSync(p, 'utf-8')).toBe('not json');
+    });
+  });
+
+  describe('isOurHookCommand', () => {
+    it('recognizes the shapes we write', () => {
+      expect(isOurHookCommand('node "/Users/x/.pixel-agents/hooks/codex-hook.js"')).toBe(true);
+      expect(isOurHookCommand('/Users/x/.pixel-agents/hooks/codex-hook.js')).toBe(true);
+      expect(isOurHookCommand('node /Users/x/.pixel-agents/hooks/codex-hook.js')).toBe(true);
+    });
+    it('recognizes a Windows path', () => {
+      expect(isOurHookCommand('node "C:/Users/x/.pixel-agents/hooks/codex-hook.js"')).toBe(true);
+    });
+    it('does not claim a stranger', () => {
+      expect(isOurHookCommand('python3 /opt/audit.py')).toBe(false);
+      expect(isOurHookCommand('node /opt/other/hook.js')).toBe(false);
+      expect(isOurHookCommand('')).toBe(false);
+    });
+    it('does not claim the Claude hook — the two must be independent', () => {
+      expect(isOurHookCommand('node "/Users/x/.pixel-agents/hooks/claude-hook.js"')).toBe(false);
+    });
+    it('ignores a relative path (cannot be verified as ours)', () => {
+      expect(isOurHookCommand('node ./codex-hook.js')).toBe(false);
+    });
+  });
+});

--- a/server/__tests__/codexHookInstaller.test.ts
+++ b/server/__tests__/codexHookInstaller.test.ts
@@ -71,6 +71,20 @@ describe('codexHookInstaller', () => {
       expect(String(handler['command'])).toContain('codex-hook.js');
     });
 
+    it('asks SessionEnd for only what Codex will honour', async () => {
+      // Codex caps SessionEnd at 3s and always runs it synchronously, ignoring
+      // `async`. Asking for 5s + async makes Codex print two warnings about
+      // clamping our own config at every single startup.
+      await installHooks('u', 't');
+      const hooks = readFile()['hooks'] as Record<
+        string,
+        Array<{ hooks: Array<Record<string, unknown>> }>
+      >;
+      const sessionEnd = hooks['SessionEnd'][0].hooks[0];
+      expect(sessionEnd['timeout']).toBe(3);
+      expect(sessionEnd['async']).toBeUndefined();
+    });
+
     it('omits matcher so every tool is observed', async () => {
       await installHooks('u', 't');
       const hooks = readFile()['hooks'] as Record<string, Array<Record<string, unknown>>>;

--- a/server/__tests__/consentGate.test.ts
+++ b/server/__tests__/consentGate.test.ts
@@ -4,8 +4,9 @@ import {
   CONSENT_DISCLOSURE,
   CONSENT_INSTALL_HEADLINE,
 } from '../src/providers/hook/claude/consentCopy.js';
+import { CONSENT_DISCLOSURE as CODEX_CONSENT_DISCLOSURE } from '../src/providers/hook/codex/consentCopy.js';
 import { consentActionFor, hooksConsentRequest } from '../src/providers/hook/consentGate.js';
-import { claudeProvider } from '../src/providers/index.js';
+import { claudeProvider, codexProvider } from '../src/providers/index.js';
 
 /**
  * consentGate is the ONE place both surfaces decide whether to ask for hooks consent and what an answer means, per
@@ -53,6 +54,44 @@ describe('hooksConsentRequest — when to ask', () => {
   // is discarded. The privilege check gates the ASK, not just the response.
   it('never asks an unprivileged client, even when everything else lines up', () => {
     expect(hooksConsentRequest({ ...askable, privileged: false }, claudeProvider)).toBeNull();
+  });
+
+  // A user without the CLI cannot evaluate an ask to edit its config and would
+  // answer only to dismiss it. Absence retires the ask rather than deferring it,
+  // which is what keeps a second bundled provider from adding a prompt for a
+  // tool the user has never installed.
+  it('does not ask when the provider CLI is not present', () => {
+    expect(hooksConsentRequest({ ...askable, present: false }, claudeProvider)).toBeNull();
+  });
+
+  it('asks when presence is unknown — omitted means present', () => {
+    // A provider that cannot cheaply tell must not lose its ask by default.
+    expect(hooksConsentRequest(askable, claudeProvider)).not.toBeNull();
+    expect(hooksConsentRequest({ ...askable, present: true }, claudeProvider)).not.toBeNull();
+  });
+});
+
+describe('hooksConsentRequest — per provider', () => {
+  const askable = {
+    installed: false,
+    hooksEnabled: true,
+    consentAnswered: false,
+    privileged: true,
+  };
+
+  it('ships the Codex provider its own id and disclosure', () => {
+    const request = hooksConsentRequest(askable, codexProvider);
+    expect(request?.providerId).toBe('codex');
+    expect(request?.disclosure).toBe(CODEX_CONSENT_DISCLOSURE);
+    // The point of a per-provider disclosure: it must name the file THIS
+    // provider writes, not the other one's.
+    expect(request?.disclosure).toContain('~/.codex/hooks.json');
+    expect(request?.disclosure).not.toContain('~/.claude/settings.json');
+  });
+
+  it("states that our Codex hooks never block, since Codex's hooks are allowed to", () => {
+    const request = hooksConsentRequest(askable, codexProvider);
+    expect(request?.disclosure).toMatch(/only watch|never returns a decision/);
   });
 });
 

--- a/server/src/cli.ts
+++ b/server/src/cli.ts
@@ -27,7 +27,14 @@ import {
 } from './configPersistence.js';
 import { MAX_PORT, MIN_PORT } from './constants.js';
 import { FileStateAdapter } from './fileStateAdapter.js';
-import { claudeProvider, copyHookScript, hookProviderById } from './providers/index.js';
+import {
+  claudeProvider,
+  codexProvider,
+  copyCodexHookScript,
+  copyHookScript,
+  hookProviderById,
+  hookProviders,
+} from './providers/index.js';
 import { PixelAgentsServer } from './server.js';
 
 // ── Argument parsing ──────────────────────────────────────────
@@ -98,6 +105,25 @@ Options:
 function copyHookScriptOrReport(packageRoot: string, context = ''): boolean {
   if (copyHookScript(packageRoot)) return true;
   console.error(`[Pixel Agents] Hooks NOT installed${context}: hook script missing.`);
+  return false;
+}
+
+/** Same contract as copyHookScriptOrReport, for a non-Claude provider. Each
+ *  provider ships its own script, so the copier is resolved by provider id
+ *  rather than assuming one shared file. */
+function copyCodexHookScriptOrReport(providerId: string, packageRoot: string): boolean {
+  const copiers: Record<string, (root: string) => boolean> = {
+    [codexProvider.id]: copyCodexHookScript,
+  };
+  const copy = copiers[providerId];
+  if (!copy) {
+    // A provider with no script copier installs nothing on this surface; that is
+    // a wiring bug, not a user error, so it is reported rather than ignored.
+    console.error(`[Pixel Agents] No hook script copier registered for "${providerId}".`);
+    return false;
+  }
+  if (copy(packageRoot)) return true;
+  console.error(`[Pixel Agents] ${providerId} hooks NOT installed: hook script missing.`);
   return false;
 }
 
@@ -270,6 +296,31 @@ async function main(): Promise<void> {
         try {
           await claudeProvider.installHooks(`http://127.0.0.1:${config.port}`, config.token);
           console.log('[Pixel Agents] Hooks installed');
+        } catch (err) {
+          console.error(`[Pixel Agents] ${err instanceof Error ? err.message : String(err)}`);
+        }
+      }
+
+      // Every OTHER bundled provider, each gated on its own consent record and
+      // presence check. Deliberately not folded into the Claude arm above:
+      // Claude carries the pre-consent migration (grant-on-already-installed)
+      // that a new provider has no history for, and a provider whose CLI is
+      // absent is skipped in SILENCE — an approval notice for a tool the user
+      // never installed is pure noise.
+      for (const provider of hookProviders) {
+        if (provider.id === claudeProvider.id) continue;
+        if (provider.isPresent?.() === false) continue;
+        if (!getHooksEnabled(provider.id)) continue;
+        if (getHooksConsent(provider.id) !== 'granted') {
+          console.log(
+            `[Pixel Agents] ${provider.displayName} hooks not installed: needs one-time approval — open the URL below to review and approve it.`,
+          );
+          continue;
+        }
+        if (!copyCodexHookScriptOrReport(provider.id, packageRoot)) continue;
+        try {
+          await provider.installHooks(`http://127.0.0.1:${config.port}`, config.token);
+          console.log(`[Pixel Agents] ${provider.displayName} hooks installed`);
         } catch (err) {
           console.error(`[Pixel Agents] ${err instanceof Error ? err.message : String(err)}`);
         }

--- a/server/src/clientMessageHandler.ts
+++ b/server/src/clientMessageHandler.ts
@@ -453,6 +453,7 @@ function handleWebviewReady(send: WsSend, ctx: ClientMessageContext): void {
             hooksEnabled: getHooksEnabled(provider.id),
             consentAnswered: getHooksConsent(provider.id) !== 'unanswered',
             privileged: ctx.privileged === true,
+            present: provider.isPresent?.() ?? true,
           },
           provider,
         );

--- a/server/src/providers/hook/codex/codex.ts
+++ b/server/src/providers/hook/codex/codex.ts
@@ -1,0 +1,302 @@
+/**
+ * Codex provider.
+ *
+ * Codex's hook surface is close enough to Claude Code's that this is mostly a
+ * name-mapping exercise, with three real differences worth calling out:
+ *
+ *  1. Tool names differ entirely. Codex's shell is `exec_command`, its editor is
+ *     `apply_patch`, and MCP tools arrive under their server-qualified names.
+ *     The read/write classification below drives the reading-vs-typing
+ *     animation, so it is the one table worth getting right.
+ *
+ *  2. Codex carries a real `tool_use_id` on PreToolUse AND PostToolUse. The
+ *     Claude provider returns a sentinel 'current' for PostToolUse because its
+ *     payload lacks the id; we can correlate properly instead.
+ *
+ *  3. Codex has no Agent Teams equivalent, so `team` is left unset. Its
+ *     SubagentStart/SubagentStop still map to sub-agent characters.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import type { AgentEvent, HookProvider } from '../../../../../core/src/provider.js';
+import {
+  areHooksInstalled as installerAreHooksInstalled,
+  installHooks as installerInstallHooks,
+  uninstallHooks as installerUninstallHooks,
+} from './codexHookInstaller.js';
+import { CONSENT_DISCLOSURE, CONSENT_INSTALL_HEADLINE } from './consentCopy.js';
+import {
+  CODEX_CONFIG_DIR,
+  CODEX_CONTEXT_WINDOW_PATTERNS,
+  CODEX_DEFAULT_CONTEXT_WINDOW,
+  CODEX_DISPLAY_NAME,
+  CODEX_PROVIDER_ID,
+  CODEX_TERMINAL_NAME_PREFIX,
+  SHELL_COMMAND_DISPLAY_MAX_LENGTH,
+} from './constants.js';
+
+// ── Tool classification ──────────────────────────────────────────────
+//
+// Verified against real rollout transcripts rather than guessed: Codex reports
+// exec_command / apply_patch / update_plan / view_image / request_user_input /
+// write_stdin, plus MCP tools under their own names.
+
+/** Tools that should render the "reading" animation instead of "typing". */
+const READING_TOOLS: ReadonlySet<string> = new Set([
+  'read_file',
+  'list_dir',
+  'grep',
+  'file_search',
+  'view_image',
+  'read_thread_terminal',
+  'list_mcp_resources',
+  'list_mcp_resource_templates',
+  'list_apps',
+]);
+
+/** Tools that never trigger the permission-wait timer: they either cannot
+ *  prompt, or their whole purpose is to wait on the user (in which case the
+ *  turnEnd/permissionRequest events already say so). */
+const PERMISSION_EXEMPT_TOOLS: ReadonlySet<string> = new Set([
+  'update_plan',
+  'view_image',
+  'read_file',
+  'list_dir',
+  'grep',
+  'file_search',
+  'request_user_input',
+]);
+
+/** Tools that spawn sub-agent characters. Codex has no Task/Agent tool; the
+ *  SubagentStart hook is the only signal, so this stays empty rather than
+ *  guessing a name that would silently never match. */
+const SUBAGENT_TOOL_NAMES: ReadonlySet<string> = new Set<string>();
+
+export function formatToolStatus(toolName: string, input?: unknown): string {
+  const inp = (input ?? {}) as Record<string, unknown>;
+  const base = (p: unknown) => (typeof p === 'string' ? path.basename(p) : '');
+  const clip = (s: string, n: number) => (s.length > n ? s.slice(0, n) + '…' : s);
+
+  switch (toolName) {
+    case 'exec_command': {
+      // Codex reports the command as a string or an argv array depending on the
+      // call site; handle both rather than rendering "[object Object]".
+      const raw = inp['command'];
+      const cmd = Array.isArray(raw) ? raw.join(' ') : typeof raw === 'string' ? raw : '';
+      return cmd ? `Running: ${clip(cmd, SHELL_COMMAND_DISPLAY_MAX_LENGTH)}` : 'Running a command';
+    }
+    case 'write_stdin':
+      return 'Typing into a command';
+    case 'apply_patch': {
+      // The patch body embeds the paths; show the first one rather than the diff.
+      const patch = typeof inp['patch'] === 'string' ? (inp['patch'] as string) : '';
+      const m = /^\*\*\* (?:Add|Update|Delete) File: (.+)$/m.exec(patch);
+      const file = m ? path.basename(m[1].trim()) : base(inp['path'] ?? inp['file_path']);
+      return file ? `Editing ${file}` : 'Editing files';
+    }
+    case 'read_file':
+      return `Reading ${base(inp['path'] ?? inp['file_path'])}` || 'Reading a file';
+    case 'list_dir':
+      return 'Listing files';
+    case 'grep':
+    case 'file_search':
+      return 'Searching code';
+    case 'view_image':
+      return 'Looking at an image';
+    case 'update_plan':
+      return 'Updating the plan';
+    case 'request_user_input':
+      return 'Waiting for your answer';
+    case 'read_thread_terminal':
+      return 'Reading terminal output';
+    default:
+      // MCP tools arrive as `server__tool` or `server.tool`; show just the tool
+      // half, which is the part that means anything to a watcher.
+      const short = toolName.split(/__|\./).pop() ?? toolName;
+      return `Using ${short}`;
+  }
+}
+
+// ── Session dirs + launch command ────────────────────────────────────
+
+/** Codex stores rollouts at ~/.codex/sessions/<YYYY>/<MM>/<DD>/rollout-*.jsonl —
+ *  date-sharded and NOT keyed by workspace, so we cannot narrow by path the way
+ *  the Claude provider does. Returning the day dirs would make the watcher scan
+ *  every project's sessions, so file fallback is deliberately not offered:
+ *  hooks are the supported path for this provider. */
+function getAllSessionRoots(): string[] {
+  return [path.join(os.homedir(), CODEX_CONFIG_DIR, 'sessions')];
+}
+
+function buildLaunchCommand(
+  _sessionId: string,
+  cwd: string,
+  opts?: { bypassPermissions?: boolean },
+): { command: string; args: string[]; env?: Record<string, string> } {
+  const args: string[] = [];
+  // Codex has no --session-id flag; it mints its own id and reports it on
+  // SessionStart, which is how the runtime learns it.
+  if (opts?.bypassPermissions) args.push('--dangerously-bypass-approvals-and-sandbox');
+  return { command: 'codex', args, env: { PWD: cwd } };
+}
+
+function contextWindowForModel(model: string | undefined): number | undefined {
+  if (!model) return undefined;
+  const m = model.toLowerCase();
+  // Longest pattern first so `gpt-4.1` cannot be shadowed by a shorter match.
+  const sorted = [...CODEX_CONTEXT_WINDOW_PATTERNS].sort((a, b) => b[0].length - a[0].length);
+  for (const [pattern, window] of sorted) {
+    if (m.includes(pattern)) return window;
+  }
+  // Any gpt-5*/codex* id gets the default window; an unrecognized family
+  // returns undefined so the runtime keeps its own estimate.
+  return m.includes('codex') || m.includes('gpt-5') ? CODEX_DEFAULT_CONTEXT_WINDOW : undefined;
+}
+
+// ── normalizeHookEvent: the single Codex-specific normalization boundary ──
+//
+// Every raw Codex field (tool_name, tool_input, agent_id, …) is read HERE and
+// HERE ONLY. Downstream sees the normalized AgentEvent union.
+
+function normalizeHookEvent(
+  raw: Record<string, unknown>,
+): { sessionId: string; event: AgentEvent } | null {
+  const eventName = raw['hook_event_name'];
+  const sessionId = raw['session_id'];
+  if (typeof eventName !== 'string' || typeof sessionId !== 'string') return null;
+
+  const str = (v: unknown): string => (typeof v === 'string' ? v : '');
+  const toolName = str(raw['tool_name']);
+  const toolInput =
+    typeof raw['tool_input'] === 'object' && raw['tool_input'] !== null
+      ? (raw['tool_input'] as Record<string, unknown>)
+      : undefined;
+  // Codex carries a real id on both Pre- and PostToolUse, so unlike the Claude
+  // provider we never need a 'current' sentinel for tool correlation.
+  const toolUseId = str(raw['tool_use_id']);
+
+  switch (eventName) {
+    case 'SessionStart':
+      return {
+        sessionId,
+        event: {
+          kind: 'sessionStart',
+          source: str(raw['source']) || undefined,
+          transcriptPath: str(raw['transcript_path']) || undefined,
+          cwd: str(raw['cwd']) || undefined,
+        },
+      };
+
+    case 'SessionEnd':
+      return {
+        sessionId,
+        event: { kind: 'sessionEnd', reason: str(raw['reason']) || undefined },
+      };
+
+    case 'PreToolUse': {
+      if (!toolName) return null;
+      return {
+        sessionId,
+        event: {
+          kind: 'toolStart',
+          toolId: toolUseId || `hook-${Date.now()}`,
+          toolName,
+          input: toolInput,
+        },
+      };
+    }
+
+    case 'PostToolUse':
+    case 'PostToolUseFailure':
+      // Without an id there is nothing to correlate; 'current' is the handler's
+      // agreed sentinel for "whatever tool is open on this session".
+      return { sessionId, event: { kind: 'toolEnd', toolId: toolUseId || 'current' } };
+
+    case 'PermissionRequest':
+      return { sessionId, event: { kind: 'permissionRequest' } };
+
+    case 'Stop':
+      // Codex's Stop means the turn finished. It has no Notification(idle_prompt)
+      // equivalent, so `awaitingInput` stays unset: the office shows "Done"
+      // rather than inventing a distinction the payload does not carry.
+      return { sessionId, event: { kind: 'turnEnd' } };
+
+    case 'SubagentStart': {
+      const agentId = str(raw['agent_id']);
+      if (!agentId) return null;
+      return {
+        sessionId,
+        event: {
+          kind: 'subagentStart',
+          parentToolId: toolUseId || 'current',
+          toolId: agentId,
+          toolName: str(raw['agent_type']) || 'subagent',
+          input: toolInput,
+        },
+      };
+    }
+
+    case 'SubagentStop': {
+      const agentId = str(raw['agent_id']);
+      if (!agentId) return null;
+      return {
+        sessionId,
+        event: { kind: 'subagentEnd', parentToolId: toolUseId || 'current', toolId: agentId },
+      };
+    }
+
+    default:
+      // Unknown or deliberately-uninstalled event (UserPromptSubmit, PreCompact,
+      // Interrupt, …). Returning null is the documented "ignore this" contract.
+      return null;
+  }
+}
+
+export const codexProvider: HookProvider = {
+  kind: 'hook',
+  id: CODEX_PROVIDER_ID,
+  displayName: CODEX_DISPLAY_NAME,
+  protocolVersion: 1,
+
+  normalizeHookEvent,
+
+  installHooks: installerInstallHooks,
+  uninstallHooks: installerUninstallHooks,
+  areHooksInstalled: installerAreHooksInstalled,
+
+  consentDisclosure: () => ({
+    headline: CONSENT_INSTALL_HEADLINE,
+    disclosure: CONSENT_DISCLOSURE,
+  }),
+
+  formatToolStatus,
+  permissionExemptTools: PERMISSION_EXEMPT_TOOLS,
+  subagentToolNames: SUBAGENT_TOOL_NAMES,
+  readingTools: READING_TOOLS,
+  terminalNamePrefix: CODEX_TERMINAL_NAME_PREFIX,
+
+  contextWindowForModel,
+  isPresent: codexLooksInstalled,
+  getAllSessionRoots,
+  buildLaunchCommand,
+};
+
+/**
+ * True when Codex looks installed for this user.
+ *
+ * Checks for ~/.codex rather than the binary on PATH: the directory is what we
+ * would be editing, it appears on Codex's first run, and a PATH probe would miss
+ * the many ways a CLI is installed while costing a process spawn on every
+ * handshake. A user with the directory but no binary is asked once and simply
+ * sees nothing happen — the harmless direction to be wrong in.
+ */
+export function codexLooksInstalled(): boolean {
+  try {
+    return fs.existsSync(path.join(os.homedir(), CODEX_CONFIG_DIR));
+  } catch {
+    return false;
+  }
+}

--- a/server/src/providers/hook/codex/codexHookInstaller.ts
+++ b/server/src/providers/hook/codex/codexHookInstaller.ts
@@ -27,8 +27,10 @@ import {
   CODEX_HOOK_SCRIPT_NAME,
   CODEX_HOOKS_FILE,
   HOOK_PATH_SUFFIX,
+  HOOK_TIMEOUT_SECONDS,
   HOOKS_BACKUP_SUFFIX,
   HOOKS_TMP_SUFFIX,
+  SESSION_END_MAX_TIMEOUT_SECONDS,
 } from './constants.js';
 
 /** One handler inside a matcher group. */
@@ -176,15 +178,27 @@ function isOurGroup(group: CodexHookGroup): boolean {
   );
 }
 
-/** The handler we install. `async: true` is the whole point: Codex runs it in
- *  the background, so the agent loop never waits on our POST even if the office
- *  is gone. The short timeout is a second belt on top of that. */
-function ourHandler(): CodexHookHandler {
+/**
+ * The handler we install for one event.
+ *
+ * `async: true` is the whole point: Codex runs it in the background, so the
+ * agent loop never waits on our POST even if the office is gone. The short
+ * timeout is a second belt on top of that.
+ *
+ * SessionEnd (and Interrupt) are the documented exceptions — Codex caps their
+ * timeout at 3s and ALWAYS runs them synchronously, ignoring `async`. Writing 5
+ * there makes Codex print two startup warnings about clamping our own config,
+ * so we ask for exactly what it will honour. The hook script's own 2s per-request
+ * timeout still bounds the synchronous case.
+ */
+function ourHandler(event: string): CodexHookHandler {
+  const synchronousEvent = event === 'SessionEnd' || event === 'Interrupt';
   return {
     type: 'command',
     command: `node "${getHookScriptPath()}"`,
-    timeout: 5,
-    async: true,
+    timeout: synchronousEvent ? SESSION_END_MAX_TIMEOUT_SECONDS : HOOK_TIMEOUT_SECONDS,
+    // Stating async on an event that ignores it is just noise in the user's file.
+    ...(synchronousEvent ? {} : { async: true }),
   };
 }
 
@@ -280,7 +294,7 @@ export async function installHooks(_serverUrl: string, _authToken: string): Prom
     const existing = next[event] ?? [];
     // No `matcher`: we want every tool, and an omitted matcher is Codex's
     // match-everything default.
-    next[event] = [...existing, { hooks: [ourHandler()] }];
+    next[event] = [...existing, { hooks: [ourHandler(event)] }];
   }
 
   writeHooksFile({ ...file, hooks: next }, hadExisting);

--- a/server/src/providers/hook/codex/codexHookInstaller.ts
+++ b/server/src/providers/hook/codex/codexHookInstaller.ts
@@ -58,7 +58,6 @@ interface CodexHooksFile {
 }
 
 export const HOOKS_UNPARSEABLE_MESSAGE = "Couldn't parse ~/.codex/hooks.json";
-export const HOOKS_CONTENDED_MESSAGE = '~/.codex/hooks.json is being modified by another process';
 
 export function hooksNotObjectMessage(): string {
   return 'hooks in ~/.codex/hooks.json is not an object — fix or remove it';

--- a/server/src/providers/hook/codex/codexHookInstaller.ts
+++ b/server/src/providers/hook/codex/codexHookInstaller.ts
@@ -1,0 +1,360 @@
+/**
+ * Installs / removes our hook entries in Codex's user-level hooks config.
+ *
+ * Target choice: we write `~/.codex/hooks.json` and never touch the user's
+ * `config.toml`. Codex accepts hooks in either place and merges them, so a
+ * standalone JSON file is strictly safer — we never parse or rewrite TOML, so a
+ * bad merge cannot corrupt their model, provider, or approval settings. Codex
+ * warns at startup if a single layer has both inline `[hooks]` and hooks.json,
+ * which is the user's own pre-existing arrangement and not something we create.
+ *
+ * Safety rules, mirroring the Claude installer:
+ *  - Back up a pre-existing hooks.json exactly once, before our first write.
+ *  - Atomic tmp-write + rename, so a crash never leaves a truncated config.
+ *  - Only ever remove entries whose command resolves to OUR script path. A
+ *    foreign hook in the same event array is preserved verbatim.
+ *  - Idempotent: installing twice yields one entry per event.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { HOOK_SCRIPTS_DIR } from '../../../constants.js';
+import {
+  CODEX_CONFIG_DIR,
+  CODEX_HOOK_EVENTS,
+  CODEX_HOOK_SCRIPT_NAME,
+  CODEX_HOOKS_FILE,
+  HOOK_PATH_SUFFIX,
+  HOOKS_BACKUP_SUFFIX,
+  HOOKS_TMP_SUFFIX,
+} from './constants.js';
+
+/** One handler inside a matcher group. */
+interface CodexHookHandler {
+  type: string;
+  command?: string;
+  timeout?: number;
+  statusMessage?: string;
+  async?: boolean;
+  [key: string]: unknown;
+}
+
+/** One matcher group in an event's array. */
+interface CodexHookGroup {
+  matcher?: string;
+  hooks: CodexHookHandler[];
+  [key: string]: unknown;
+}
+
+/** Partial shape of hooks.json — only `hooks` is ours to touch; every other
+ *  top-level key (e.g. `description`) is preserved as-is. */
+interface CodexHooksFile {
+  hooks?: Record<string, CodexHookGroup[]>;
+  [key: string]: unknown;
+}
+
+export const HOOKS_UNPARSEABLE_MESSAGE = "Couldn't parse ~/.codex/hooks.json";
+export const HOOKS_CONTENDED_MESSAGE = '~/.codex/hooks.json is being modified by another process';
+
+export function hooksNotObjectMessage(): string {
+  return 'hooks in ~/.codex/hooks.json is not an object — fix or remove it';
+}
+export function eventNotArrayMessage(event: string): string {
+  return `hooks.${event} in ~/.codex/hooks.json is not an array — fix or remove it`;
+}
+
+/** Absolute path to ~/.codex/hooks.json. */
+export function getCodexHooksPath(): string {
+  return path.join(os.homedir(), CODEX_CONFIG_DIR, CODEX_HOOKS_FILE);
+}
+
+/** Absolute path to the installed hook script. */
+export function getHookScriptPath(): string {
+  return path.join(os.homedir(), HOOK_SCRIPTS_DIR, CODEX_HOOK_SCRIPT_NAME);
+}
+
+/** Read hooks.json, or an empty object when absent. Throws on malformed JSON so
+ *  the caller can surface it rather than silently overwriting the user's file. */
+function readHooksFile(): CodexHooksFile {
+  const p = getCodexHooksPath();
+  let raw: string;
+  try {
+    raw = fs.readFileSync(p, 'utf-8');
+  } catch {
+    return {}; // absent is normal — we create it
+  }
+  if (raw.trim() === '') return {};
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(HOOKS_UNPARSEABLE_MESSAGE);
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error(HOOKS_UNPARSEABLE_MESSAGE);
+  }
+  return parsed as CodexHooksFile;
+}
+
+/** Atomic write: tmp file next to the target, then rename. Creates ~/.codex if
+ *  needed. A one-time backup of a pre-existing file is written first. */
+function writeHooksFile(next: CodexHooksFile, hadExisting: boolean): void {
+  const p = getCodexHooksPath();
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+
+  if (hadExisting) {
+    const backup = p + HOOKS_BACKUP_SUFFIX;
+    if (!fs.existsSync(backup)) {
+      try {
+        fs.copyFileSync(p, backup);
+      } catch {
+        /* a failed backup must not block the install; the write is still atomic */
+      }
+    }
+  }
+
+  const tmp = p + HOOKS_TMP_SUFFIX;
+  // 0o600: the file records a local port and bearer token path; no reason for
+  // it to be group/world readable.
+  fs.writeFileSync(tmp, JSON.stringify(next, null, 2) + '\n', { mode: 0o600 });
+  fs.renameSync(tmp, p);
+}
+
+/**
+ * First shell token of a command, normalized to forward slashes, or null when
+ * it isn't an absolute path. `node "<script>"` and a bare `<script>` are the two
+ * shapes we write (and the two a user plausibly hand-edits).
+ */
+function firstCommandToken(command: string): string | null {
+  const trimmed = command.trim();
+  const nodeInvocation = /^"?(?:[^"]*[/\\])?node(?:\.exe)?"?\s+(.+)$/.exec(trimmed);
+  const raw = nodeInvocation ? nodeInvocation[1] : trimmed;
+  const token = readToken(raw.trim());
+  if (token === null) return null;
+  const normalized = token.replace(/\\/g, '/');
+  const absolute = normalized.startsWith('/') || /^[a-zA-Z]:\//.test(normalized);
+  return absolute ? normalized : null;
+}
+
+/** Read one shell token: a quoted string, or chars up to the first terminator.
+ *  Returns null when empty or unterminated. */
+function readToken(raw: string): string | null {
+  if (raw === '') return null;
+  const quote = raw[0];
+  if (quote === '"' || quote === "'") {
+    const end = raw.indexOf(quote, 1);
+    if (end <= 1) return null; // unterminated, or empty quotes
+    return raw.slice(1, end);
+  }
+  const match = /^[^\s"';|&]+/.exec(raw);
+  return match ? match[0] : null;
+}
+
+/**
+ * True when this command runs OUR hook script.
+ *
+ * Matched by path SUFFIX rather than equality with getHookScriptPath(): the
+ * absolute path differs across installs (a different home dir, a symlinked
+ * home, a Windows drive-letter case), and failing to recognize our own entry
+ * would leave a duplicate behind on every reinstall. The suffix is
+ * brand-specific (`/codex-hook.js`), so it cannot match a stranger's hook.
+ */
+export function isOurHookCommand(command: string): boolean {
+  const token = firstCommandToken(command);
+  if (token === null) return false;
+  return token.toLowerCase().endsWith(HOOK_PATH_SUFFIX);
+}
+
+/** True when a group contains only our handlers (so removing the whole group
+ *  drops nothing of the user's). */
+function isOurGroup(group: CodexHookGroup): boolean {
+  if (!Array.isArray(group.hooks) || group.hooks.length === 0) return false;
+  return group.hooks.every(
+    (h) => typeof h?.command === 'string' && isOurHookCommand(h.command as string),
+  );
+}
+
+/** The handler we install. `async: true` is the whole point: Codex runs it in
+ *  the background, so the agent loop never waits on our POST even if the office
+ *  is gone. The short timeout is a second belt on top of that. */
+function ourHandler(): CodexHookHandler {
+  return {
+    type: 'command',
+    command: `node "${getHookScriptPath()}"`,
+    timeout: 5,
+    async: true,
+  };
+}
+
+/** Drop every group of ours from an event array, preserving foreign groups and
+ *  foreign handlers inside mixed groups. Returns the filtered array. */
+function stripOurGroups(groups: CodexHookGroup[]): CodexHookGroup[] {
+  const out: CodexHookGroup[] = [];
+  for (const group of groups) {
+    // A non-object element is the user's problem, not ours — preserve it rather
+    // than silently deleting data we don't understand.
+    if (typeof group !== 'object' || group === null || !Array.isArray(group.hooks)) {
+      out.push(group);
+      continue;
+    }
+    if (isOurGroup(group)) continue; // entirely ours — drop
+    const kept = group.hooks.filter(
+      (h) => !(typeof h?.command === 'string' && isOurHookCommand(h.command as string)),
+    );
+    if (kept.length === group.hooks.length) {
+      out.push(group); // nothing of ours in here
+    } else if (kept.length > 0) {
+      out.push({ ...group, hooks: kept }); // mixed group — keep the stranger's
+    }
+    // kept.length === 0 with a length change means every handler was ours
+    // inside a group that also carried other keys; dropping it is correct.
+  }
+  return out;
+}
+
+/** Copy the shipped hook script to ~/.pixel-agents/hooks/. Returns false when
+ *  the source is missing or the copy fails, so the caller reports the failure
+ *  instead of logging a false success: a hooks entry pointing at a missing
+ *  script makes Codex spawn a dead `node` for every event, which is worse than
+ *  no hooks at all. Mirrors the Claude installer's contract. */
+export function copyHookScript(extensionPath: string): boolean {
+  const src = path.join(extensionPath, 'dist', 'hooks', CODEX_HOOK_SCRIPT_NAME);
+  const dst = getHookScriptPath();
+  const dstDir = path.dirname(dst);
+
+  try {
+    if (!fs.existsSync(dstDir)) {
+      fs.mkdirSync(dstDir, { recursive: true, mode: 0o700 });
+    }
+    if (!fs.existsSync(src)) {
+      console.warn(`[Pixel Agents] Codex hook script not found at ${src}`);
+      return false;
+    }
+    fs.copyFileSync(src, dst);
+    fs.chmodSync(dst, 0o700);
+    console.log(`[Pixel Agents] Codex hook script installed at ${dst}`);
+    return true;
+  } catch (e) {
+    console.error(`[Pixel Agents] Failed to copy Codex hook script: ${e}`);
+    return false;
+  }
+}
+
+/**
+ * Install our handler for every event in CODEX_HOOK_EVENTS.
+ *
+ * Idempotent: existing entries of ours are stripped first, so a reinstall (or an
+ * upgrade that changes the handler shape) converges to exactly one per event.
+ * Also sweeps events we no longer install, so a legacy install that carried a
+ * wider surface is narrowed on the next run.
+ *
+ * `serverUrl`/`authToken` are accepted for interface parity with the Claude
+ * provider but intentionally unused: the script discovers live servers through
+ * ~/.pixel-agents/servers/ at call time, which keeps a stale port out of the
+ * user's config file.
+ */
+export async function installHooks(_serverUrl: string, _authToken: string): Promise<void> {
+  const p = getCodexHooksPath();
+  const hadExisting = fs.existsSync(p);
+  const file = readHooksFile();
+
+  const hooks = file.hooks ?? {};
+  if (typeof hooks !== 'object' || hooks === null || Array.isArray(hooks)) {
+    throw new Error(hooksNotObjectMessage());
+  }
+
+  const next: Record<string, CodexHookGroup[]> = {};
+  // Sweep EVERY event present, not just the ones we install: an event we
+  // dropped from the list must lose our entry too.
+  for (const [event, groups] of Object.entries(hooks)) {
+    if (!Array.isArray(groups)) {
+      throw new Error(eventNotArrayMessage(event));
+    }
+    const stripped = stripOurGroups(groups);
+    if (stripped.length > 0) next[event] = stripped;
+  }
+
+  for (const event of CODEX_HOOK_EVENTS) {
+    const existing = next[event] ?? [];
+    // No `matcher`: we want every tool, and an omitted matcher is Codex's
+    // match-everything default.
+    next[event] = [...existing, { hooks: [ourHandler()] }];
+  }
+
+  writeHooksFile({ ...file, hooks: next }, hadExisting);
+}
+
+/** Remove every entry of ours, leaving foreign hooks untouched. Deletes the
+ *  `hooks` key (and the file, when it holds nothing else) rather than leaving an
+ *  empty scaffold behind. */
+export async function uninstallHooks(): Promise<void> {
+  const p = getCodexHooksPath();
+  if (!fs.existsSync(p)) return;
+
+  const file = readHooksFile();
+  const hooks = file.hooks;
+  if (typeof hooks !== 'object' || hooks === null || Array.isArray(hooks)) {
+    return; // nothing of ours can be in a shape we didn't write
+  }
+
+  const next: Record<string, CodexHookGroup[]> = {};
+  for (const [event, groups] of Object.entries(hooks)) {
+    if (!Array.isArray(groups)) {
+      next[event] = groups as unknown as CodexHookGroup[]; // preserve as-is
+      continue;
+    }
+    const stripped = stripOurGroups(groups);
+    if (stripped.length > 0) next[event] = stripped;
+  }
+
+  const rest = { ...file };
+  delete rest.hooks;
+
+  if (Object.keys(next).length > 0) {
+    writeHooksFile({ ...rest, hooks: next }, true);
+    return;
+  }
+
+  // Nothing left under `hooks`. If the file carried nothing else, remove it.
+  if (Object.keys(rest).length === 0) {
+    try {
+      fs.unlinkSync(p);
+    } catch {
+      /* best effort */
+    }
+    return;
+  }
+  writeHooksFile(rest, true);
+}
+
+/** True when our handler is installed for every event we claim. A partial
+ *  install reports false, so the caller reinstalls and converges. */
+export async function areHooksInstalled(): Promise<boolean> {
+  let file: CodexHooksFile;
+  try {
+    file = readHooksFile();
+  } catch {
+    return false; // unparseable — we cannot claim an install
+  }
+  const hooks = file.hooks;
+  if (typeof hooks !== 'object' || hooks === null || Array.isArray(hooks)) return false;
+
+  return CODEX_HOOK_EVENTS.every((event) => {
+    const groups = hooks[event];
+    if (!Array.isArray(groups)) return false;
+    return groups.some(
+      (g) =>
+        typeof g === 'object' &&
+        g !== null &&
+        Array.isArray(g.hooks) &&
+        g.hooks.some(
+          (h) => typeof h?.command === 'string' && isOurHookCommand(h.command as string),
+        ),
+    );
+  });
+}
+
+export { CODEX_HOOK_EVENTS, isOurGroup, ourHandler, readHooksFile, stripOurGroups, writeHooksFile };
+export type { CodexHookGroup, CodexHookHandler, CodexHooksFile };

--- a/server/src/providers/hook/codex/consentCopy.ts
+++ b/server/src/providers/hook/codex/consentCopy.ts
@@ -1,0 +1,61 @@
+/**
+ * Disclosure text for the Codex hooks consent gate. Same contract as the Claude
+ * provider's: the server ships these strings in `hooksConsentRequest` and the
+ * webview renders them verbatim, so there is exactly one copy of the terms.
+ *
+ * The event count is interpolated from CODEX_HOOK_EVENTS, never written out: a
+ * hardcoded number silently becomes a lie the next time the list changes.
+ */
+
+import { CODEX_HOOK_EVENTS, HOOKS_BACKUP_SUFFIX } from './constants.js';
+
+const HOOKS_FILE = '~/.codex/hooks.json';
+
+/** WHY we ask + WHAT we write.
+ *
+ *  Names hooks.json specifically, because the reassuring part is what we do NOT
+ *  touch: Codex also accepts hooks inline in config.toml, and a user who has
+ *  model/provider/approval settings there deserves to know we leave that file
+ *  alone. */
+export const CONSENT_FACT_WHAT =
+  `To bring your agents to life in real time, Pixel Agents adds hooks for ` +
+  `${CODEX_HOOK_EVENTS.length} Codex events to ${HOOKS_FILE}. ` +
+  `Your config.toml is not touched, existing hooks are kept, and a one-time backup ` +
+  `is saved as hooks.json${HOOKS_BACKUP_SUFFIX}.`;
+
+/** WHAT data moves, and where it stops.
+ *
+ *  Same honesty constraint as the Claude copy: `--host 0.0.0.0` binds the server
+ *  to every interface, so this states the default and names the one thing that
+ *  changes it rather than promising something the software can be asked to break. */
+export const CONSENT_FACT_DATA =
+  'Codex will send those events - including tool names and tool inputs - to a Pixel Agents ' +
+  'server on this machine. Everything stays local - the server listens only on 127.0.0.1 - unless ' +
+  'you explicitly start it with --host to expose it on your network.';
+
+/** WHAT we deliberately do NOT do.
+ *
+ *  Codex-specific and worth stating plainly: its PreToolUse hook is allowed to
+ *  deny a tool call outright and PermissionRequest can pre-approve one. A user
+ *  who has read the Codex docs has every reason to ask whether we use that
+ *  power. We do not, and the hook script emits no decision field at all. */
+export const CONSENT_FACT_PASSIVE =
+  'These hooks only watch. Codex lets a hook block a tool call or auto-approve a permission ' +
+  'prompt; Pixel Agents does neither - it never returns a decision, so Codex behaves exactly ' +
+  'the same whether or not the office is running.';
+
+/** HOW to undo it. */
+export const CONSENT_FACT_REVERSIBLE =
+  'You can remove the hooks at any time from Settings → Instant Detection (Hooks).';
+
+/** Headline for the first-run gate. Carries NO disclosure facts by design. */
+export const CONSENT_INSTALL_HEADLINE = 'One more thing: Codex hooks!';
+
+/** The disclosure facts, in order, as one block. The IntroBubble splits on the
+ *  blank lines and renders every paragraph on the decision surface itself. */
+export const CONSENT_DISCLOSURE = [
+  CONSENT_FACT_WHAT,
+  CONSENT_FACT_DATA,
+  CONSENT_FACT_PASSIVE,
+  CONSENT_FACT_REVERSIBLE,
+].join('\n\n');

--- a/server/src/providers/hook/codex/constants.ts
+++ b/server/src/providers/hook/codex/constants.ts
@@ -86,3 +86,12 @@ export const CODEX_CONTEXT_WINDOW_PATTERNS: ReadonlyArray<readonly [string, numb
 
 /** Max chars of a shell command rendered in the status line. */
 export const SHELL_COMMAND_DISPLAY_MAX_LENGTH = 40;
+
+/** Timeout we request for a normal hook. Generous relative to the script's own
+ *  2s per-request budget; it exists only so a wedged `node` cannot sit around. */
+export const HOOK_TIMEOUT_SECONDS = 5;
+
+/** Codex caps SessionEnd and Interrupt at 3s (default 1s) and runs them
+ *  synchronously even when `async: true`. Asking for more makes Codex print a
+ *  clamping warning about our own config at every startup. */
+export const SESSION_END_MAX_TIMEOUT_SECONDS = 3;

--- a/server/src/providers/hook/codex/constants.ts
+++ b/server/src/providers/hook/codex/constants.ts
@@ -29,8 +29,6 @@ export const CODEX_HOOK_EVENTS = [
   'SubagentStop',
 ] as const;
 
-export type CodexHookEvent = (typeof CODEX_HOOK_EVENTS)[number];
-
 /** Provider id on the wire. Must stay stable: it keys the consent record and
  *  the hooks-enabled setting. */
 export const CODEX_PROVIDER_ID = 'codex';

--- a/server/src/providers/hook/codex/constants.ts
+++ b/server/src/providers/hook/codex/constants.ts
@@ -1,0 +1,88 @@
+/**
+ * Codex-specific constants. Kept in one file so the hook surface (which events
+ * we install) and the display strings are auditable in a single place.
+ */
+
+/** Hook events to install in Codex's hooks config. This list is the whole
+ *  data-collection surface: Codex runs each of these and pipes the payload to
+ *  our local server, so an event we do not act on is scope we should not ask for.
+ *
+ *  SessionStart/SessionEnd handle session lifecycle.
+ *  PreToolUse/PostToolUse drive the typing/reading animations.
+ *  PermissionRequest raises the "needs you" speech bubble.
+ *  Stop ends the turn (character stands up / goes idle).
+ *  SubagentStart/SubagentStop spawn and retire sub-agent characters.
+ *
+ *  Deliberately NOT installed, mirroring the Claude provider's restraint:
+ *  - UserPromptSubmit: would forward the user's prompt text for nothing the
+ *    runtime consumes.
+ *  - PreCompact/PostCompact: compaction is invisible in the office.
+ *  - Interrupt: Stop already returns the character to idle. */
+export const CODEX_HOOK_EVENTS = [
+  'SessionStart',
+  'SessionEnd',
+  'PreToolUse',
+  'PostToolUse',
+  'PermissionRequest',
+  'Stop',
+  'SubagentStart',
+  'SubagentStop',
+] as const;
+
+export type CodexHookEvent = (typeof CODEX_HOOK_EVENTS)[number];
+
+/** Provider id on the wire. Must stay stable: it keys the consent record and
+ *  the hooks-enabled setting. */
+export const CODEX_PROVIDER_ID = 'codex';
+
+export const CODEX_DISPLAY_NAME = 'Codex';
+
+/** Terminal name prefix used when launching the CLI, so the VS Code adapter can
+ *  match terminals to agents. */
+export const CODEX_TERMINAL_NAME_PREFIX = 'Codex';
+
+/** Directory holding Codex's user-level config, relative to the home dir. */
+export const CODEX_CONFIG_DIR = '.codex';
+
+/** Standalone hooks file we write. Codex also supports inline `[hooks]` tables
+ *  in config.toml, but a separate JSON file is the safer target: we never have
+ *  to parse or rewrite the user's TOML, so a malformed merge cannot break their
+ *  model/provider settings. */
+export const CODEX_HOOKS_FILE = 'hooks.json';
+
+/** One-time backup of a pre-existing hooks.json, written before our first
+ *  modification. Brand-named rather than a generic `.backup`, which would
+ *  collide with another tool's convention: a foreign `.backup` next to
+ *  hooks.json must not make us believe we already saved the user's original. */
+export const HOOKS_BACKUP_SUFFIX = '.pixel-agents.backup';
+
+/** Suffix of the temp file used for the atomic tmp-write + rename. */
+export const HOOKS_TMP_SUFFIX = '.pixel-agents-tmp';
+
+/** Where the hook script is installed (under the shared ~/.pixel-agents tree,
+ *  alongside the Claude one). */
+export const CODEX_HOOK_SCRIPT_NAME = 'codex-hook.js';
+
+/** Path fragment identifying a command as ours, used when deciding whether an
+ *  entry in the user's hooks.json belongs to us and may be removed. */
+export const HOOK_PATH_SUFFIX = `/${CODEX_HOOK_SCRIPT_NAME}`;
+
+/** Codex context windows, by model family. Only the provider can map a model id
+ *  a transcript reports to the window it counts against, and getting it wrong is
+ *  visible: the office renders usage/window as a context gauge over every
+ *  character. Conservative by design — the runtime widens its estimate if a real
+ *  context ever exceeds what we return. */
+export const CODEX_DEFAULT_CONTEXT_WINDOW = 272_000;
+
+/** Models whose window differs from the default. Matched case-insensitively as
+ *  substrings, longest first, because Codex reports ids with date and variant
+ *  suffixes (`gpt-5.1-codex-max-20260115`) that we must not enumerate. */
+export const CODEX_CONTEXT_WINDOW_PATTERNS: ReadonlyArray<readonly [string, number]> = [
+  ['gpt-4.1', 1_047_576],
+  ['gpt-4o', 128_000],
+  ['o3', 200_000],
+  ['o4', 200_000],
+];
+
+/** Max chars of a shell command rendered in the status line. */
+export const SHELL_COMMAND_DISPLAY_MAX_LENGTH = 40;

--- a/server/src/providers/hook/codex/hooks/codex-hook.ts
+++ b/server/src/providers/hook/codex/hooks/codex-hook.ts
@@ -1,0 +1,187 @@
+/**
+ * Codex hook script. Codex spawns this once per lifecycle event with the event
+ * payload on stdin; we forward it to every live Pixel Agents server and exit.
+ *
+ * Contract, identical to the Claude script's and for the same reasons:
+ *  - Never block, veto, or rewrite anything. Codex's PreToolUse CAN deny a tool
+ *    call, and PermissionRequest CAN pre-approve one — we deliberately use
+ *    neither. This script emits no decision, so Codex's own behaviour is
+ *    unchanged whether or not the office is running.
+ *  - Never fail loudly. Every error path (no server, bad stdin, refused
+ *    connection, timeout, non-2xx) resolves quietly and the process exits 0, so
+ *    a stopped office can never wedge the agent loop.
+ *  - Never be slow. 2s per-request timeout, requests fan out in parallel.
+ */
+
+import * as fs from 'fs';
+import * as http from 'http';
+import * as os from 'os';
+import * as path from 'path';
+
+import {
+  HOOK_API_PREFIX,
+  SERVER_JSON_DIR,
+  SERVER_JSON_NAME,
+  SERVERS_DIR,
+} from '../../../../constants.js';
+import type { ServerConfig, ServerTarget } from '../../../../serverConfig.js';
+import { isServerConfig, isServerTarget } from '../../../../serverConfig.js';
+import { CODEX_PROVIDER_ID } from '../constants.js';
+
+const SERVER_JSON = path.join(os.homedir(), SERVER_JSON_DIR, SERVER_JSON_NAME);
+const SERVERS_REGISTRY_DIR = path.join(os.homedir(), SERVER_JSON_DIR, SERVERS_DIR);
+
+/** Diagnostic log, mirroring the Claude script: hook delivery is otherwise
+ *  100% silent, so a dropped event is invisible in CI. Zero cost when unset. */
+let debugLogPath = process.env['PIXEL_AGENTS_DEBUG_LOG'];
+function hookDebug(line: string): void {
+  if (!debugLogPath) return;
+  try {
+    fs.appendFileSync(debugLogPath, `${new Date().toISOString()} CODEXHOOK ${line}\n`);
+  } catch {
+    /* never let diagnostics break the hook */
+  }
+}
+
+/** True if a process with this PID is alive. Best-effort: a false positive on
+ *  PID reuse costs one harmless failed POST, never a crash. */
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Every live server under ~/.pixel-agents/servers/, so one event reaches a
+ *  VS Code-embedded server and a standalone `npx pixel-agents` at once. Empty
+ *  when absent/unreadable; the caller then falls back to legacy server.json. */
+function readRegistry(): ServerConfig[] {
+  let files: string[];
+  try {
+    files = fs.readdirSync(SERVERS_REGISTRY_DIR).filter((f) => f.endsWith('.json'));
+  } catch {
+    return [];
+  }
+
+  const live: ServerConfig[] = [];
+  for (const file of files) {
+    const filePath = path.join(SERVERS_REGISTRY_DIR, file);
+    try {
+      const entry = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as unknown;
+      if (!isServerConfig(entry)) {
+        hookDebug(`registry-skip reason=malformed file=${file} err=invalid-server-config`);
+        continue;
+      }
+      if (isProcessAlive(entry.pid)) {
+        live.push(entry);
+      } else {
+        hookDebug(`registry-skip reason=dead-pid file=${file} pid=${entry.pid}`);
+      }
+    } catch (e) {
+      hookDebug(
+        `registry-skip reason=malformed file=${file} err=${e instanceof Error ? e.message : String(e)}`,
+      );
+    }
+  }
+  return live;
+}
+
+/** POST one event to one server. Every failure path resolves quietly: a drop to
+ *  one server must not affect any other, nor this script's exit code. */
+function postToServer(
+  server: ServerTarget,
+  body: string,
+  eventName: string,
+  sid: string,
+): Promise<void> {
+  hookDebug(`POST event=${eventName} sid=${sid} port=${server.port}`);
+  return new Promise((resolve) => {
+    try {
+      const req = http.request(
+        {
+          hostname: '127.0.0.1',
+          port: server.port,
+          path: `${HOOK_API_PREFIX}/${CODEX_PROVIDER_ID}`,
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Content-Length': Buffer.byteLength(body),
+            Authorization: `Bearer ${server.token}`,
+          },
+          timeout: 2000,
+        },
+        (res) => {
+          hookDebug(
+            `POST-done event=${eventName} sid=${sid} status=${res.statusCode} port=${server.port}`,
+          );
+          res.resume();
+          resolve();
+        },
+      );
+      req.on('error', (err) => {
+        hookDebug(
+          `POST-error event=${eventName} sid=${sid} port=${server.port} err=${err.message}`,
+        );
+        resolve();
+      });
+      req.on('timeout', () => {
+        hookDebug(`POST-timeout event=${eventName} sid=${sid} port=${server.port}`);
+        req.destroy();
+        resolve();
+      });
+      req.end(body);
+    } catch (err) {
+      hookDebug(
+        `POST-error event=${eventName} sid=${sid} port=${server.port} err=${err instanceof Error ? err.message : String(err)}`,
+      );
+      resolve();
+    }
+  });
+}
+
+async function main(): Promise<void> {
+  let input = '';
+  for await (const chunk of process.stdin) input += chunk;
+
+  let data: Record<string, unknown>;
+  try {
+    data = JSON.parse(input) as Record<string, unknown>;
+  } catch {
+    hookDebug('exit reason=bad-stdin');
+    process.exit(0);
+  }
+
+  const eventName = (data['hook_event_name'] as string | undefined) ?? '?';
+  const sid = (data['session_id'] as string | undefined)?.slice(0, 8) ?? '?';
+
+  let servers: ServerTarget[] = readRegistry();
+  if (servers.length === 0) {
+    try {
+      const legacy = JSON.parse(fs.readFileSync(SERVER_JSON, 'utf-8')) as unknown;
+      if (!isServerTarget(legacy)) {
+        throw new Error('invalid legacy server config');
+      }
+      servers = [legacy];
+    } catch (e) {
+      hookDebug(
+        `exit reason=no-server-json event=${eventName} sid=${sid} path=${SERVER_JSON} err=${e instanceof Error ? e.message : String(e)}`,
+      );
+      process.exit(0);
+    }
+  }
+
+  if (!debugLogPath) {
+    const withDebugLog = servers.find((s) => (s as ServerConfig).debugLog);
+    const p = (withDebugLog as ServerConfig | undefined)?.debugLog;
+    if (p) debugLogPath = p;
+  }
+
+  const body = JSON.stringify(data);
+  await Promise.all(servers.map((server) => postToServer(server, body, eventName, sid)));
+}
+
+main()
+  .catch(() => {})
+  .finally(() => process.exit(0));

--- a/server/src/providers/hook/consentGate.ts
+++ b/server/src/providers/hook/consentGate.ts
@@ -24,18 +24,24 @@ export interface ConsentGateState {
    *  server token. Showing the dialog to a client whose answer would be
    *  ignored is a lie, so it gates the ASK and not just the response. */
   privileged: boolean;
+  /** Does the provider's CLI look installed for this user (provider.isPresent,
+   *  defaulted to true when the provider cannot tell)? Someone without the tool
+   *  cannot evaluate an ask to edit its config and would answer only to dismiss
+   *  it, so absence retires the ask. Omitted = present. */
+  present?: boolean;
 }
 
 /**
  * The `hooksConsentRequest` for one provider's `webviewReady` handshake, or null when this client must not be asked.
  * Each condition is a reason the ask would be WRONG, not merely redundant: nothing to approve, already answered
- * durably, a preference turned off, or a client whose answer would be dropped. All four are checked in their own
- * right, so a hand-edited config cannot resurrect a retired ask.
+ * durably, a preference turned off, a client whose answer would be dropped, or a CLI that isn't installed. Each is
+ * checked in its own right, so a hand-edited config cannot resurrect a retired ask.
  */
 export function hooksConsentRequest(
   state: ConsentGateState,
   provider: Pick<HookProvider, 'id' | 'consentDisclosure'>,
 ): HooksConsentRequest | null {
+  if (state.present === false) return null;
   if (state.installed || state.consentAnswered || !state.hooksEnabled || !state.privileged) {
     return null;
   }

--- a/server/src/providers/index.ts
+++ b/server/src/providers/index.ts
@@ -13,14 +13,16 @@
 
 import type { HookProvider } from '../../../core/src/provider.js';
 import { claudeProvider } from './hook/claude/claude.js';
+import { codexProvider } from './hook/codex/codex.js';
 
-export { claudeProvider };
+export { claudeProvider, codexProvider };
 export { copyHookScript } from './hook/claude/claudeHookInstaller.js';
+export { copyHookScript as copyCodexHookScript } from './hook/codex/codexHookInstaller.js';
 
 /** Every bundled hook provider, in registration order. The consent gate loops
  *  over this at the webviewReady handshake (one ask per provider that needs
  *  one) and `hooksConsentResponse` resolves its provider id against it. */
-export const hookProviders: readonly HookProvider[] = [claudeProvider];
+export const hookProviders: readonly HookProvider[] = [claudeProvider, codexProvider];
 
 /** Resolve a wire-supplied provider id, or undefined for an unknown one —
  *  the caller writes nothing on undefined (fail-closed, like a junk choice). */


### PR DESCRIPTION
## What changed

Codex now ships an official [hooks API](https://learn.chatgpt.com/docs/hooks) whose lifecycle events line up closely with Claude Code's, so this implements `HookProvider` for it rather than introducing a new provider type. `server/src/providers/hook/codex/` is a single new subdirectory, which is what the interface docstring promised a new tool would cost.

### Provider

- `normalizeHookEvent` maps `SessionStart`/`SessionEnd`, `PreToolUse`/`PostToolUse`, `PermissionRequest`, `Stop`, and `SubagentStart`/`SubagentStop`.
- Codex carries a real `tool_use_id` on **both** `PreToolUse` and `PostToolUse`, so tool correlation uses it instead of the `'current'` sentinel the Claude provider needs (it still falls back to the sentinel if the id is ever absent).
- Tool tables are built from Codex's actual tool names — `exec_command`, `apply_patch`, `update_plan`, `view_image`, `write_stdin`, `read_thread_terminal` — read off real rollout transcripts rather than guessed. `formatToolStatus` parses the `apply_patch` body for a filename and handles `command` arriving as either a string or an argv array.
- `Stop` maps to `turnEnd` **without** `awaitingInput`. Codex has no `Notification(idle_prompt)` equivalent, and synthesizing one would label a finished turn as "waiting for input".
- `subagentToolNames` is deliberately empty: Codex has no `Task`-style tool, and the `SubagentStart` hook is the only real signal. Guessing a name would produce a set that silently never matches.

### Installer

Writes `~/.codex/hooks.json` and never touches `config.toml`. Codex accepts hooks in either place and merges them, so the standalone JSON file means we never parse or rewrite the user's TOML — a bad merge cannot corrupt their model, provider, or approval settings.

Same safety rules as `claudeHookInstaller`: one-time backup before first write, atomic tmp-write + rename, idempotent install, and **only** ever removing entries whose command resolves to our own script. A foreign hook survives install and uninstall, including when it shares a group with ours.

### Passive by construction

Handlers are installed with `async: true`, and the hook script returns no decision field at all.

This matters more for Codex than for Claude Code: Codex's `PreToolUse` is allowed to **deny** a tool call outright, and `PermissionRequest` can pre-approve one. We use neither, so Codex behaves identically whether or not the office is running. The consent copy states this explicitly, since a user who has read the Codex hook docs has every reason to ask.

## Two shared changes

Both were needed to bundle a second provider at all; I kept each as small as I could.

**1. `HookProvider.isPresent?()` + a consent-gate condition.** Without it, adding a second bundled provider asks every Claude-only user to approve edits to the config of a tool they don't have — a prompt they cannot evaluate and would answer only to dismiss. Absent = treated as present, so no existing provider changes behaviour. It gates only the *ask*, never event handling: a provider that reports false but then sends events is still served, because the events prove it's there.

This surfaced as three `consentFlow` test failures the moment `codexProvider` was registered, which is the test suite doing its job.

**2. `buildHooks()` takes multiple entry points.** With more than one entry esbuild mirrors the shared source tree into `outdir` (`dist/hooks/claude/hooks/claude-hook.js`), which would have broken every existing consumer — the installers, both package contracts, and any already-installed `settings.json` entry. `outbase` + `entryNames: '[name]'` keeps the output flat.

## Testing

- **81 new tests** (45 provider, 32 installer, 4 consent gate); full server suite **631 passing**, 0 failing.
- Installer tests run against a throwaway `HOME` and cover the cases worth being paranoid about: a foreign hook preserved through install *and* uninstall, our handler stripped out of a group shared with a stranger, backup written exactly once (a second install must not overwrite the pristine copy with our own modified content), malformed JSON refused rather than overwritten, and no temp file left behind.
- `npm run check-types`, `npm run lint`, `npm run format:check`, `npm run test:package-contract`, `asyncapi:generate` and `e2e:inventory` all clean with **no drift**.

**Verified end to end** against a locally built server on a machine with Codex installed: the CLI reports the provider and asks for its own consent, Codex-shaped hook payloads POSTed to `/api/hooks/codex` are normalized, the session is adopted (`PreToolUse confirmed external session`), and the character renders and animates in the office alongside a Claude Code agent.

```
[Pixel Agents] Codex hooks not installed: needs one-time approval — open the URL below to review and approve it.
[Pixel Agents] Hook: SessionStart(source=startup, session=cdx-1...)
[Pixel Agents] Hook: PreToolUse confirmed external session cdx-1..., notifying host
[Pixel Agents] Hook: Agent 2 - PreToolUse (session=cdx-1...)
[Pixel Agents] Hook: Agent 2 - PostToolUse (session=cdx-1...)
```

## Found by running it for real

Two defects the synthetic POST tests passed straight through. Both are fixed here, and both are the reason I'd suggest a reviewer install the hooks once rather than trusting the suite alone.

**1. Codex clamps `SessionEnd` and says so, every startup.** `SessionEnd` and `Interrupt` cap at 3s and always run synchronously, ignoring `async`. Installing 5s + async made Codex print two warnings about clamping our own config on every single run:

```
warning: clamping SessionEnd hook timeout to 3s in ~/.codex/hooks.json
warning: running async SessionEnd hook synchronously in ~/.codex/hooks.json
```

The installer now asks for exactly what Codex will honour. The hook script's own 2s per-request timeout still bounds the synchronous case.

**2. The hook script was built but never packed.** `package.json` `files` is a whitelist, so `dist/hooks/codex-hook.js` never made it into the tarball — `verify:npm-package` fails on it. Left unfixed, an npm install would write a `hooks.json` entry pointing at a script that isn't there, making Codex spawn a dead `node` for every event: strictly worse than no hooks. Added to `files`, both package contracts, and the VSIX manifest.

## One thing worth knowing about Codex hook trust

Unlike Claude Code, Codex will not run a non-managed hook until the user trusts its exact definition (it records a hash, so any edit re-arms review). An untrusted hook is **silently skipped** — no prompt at the moment it would fire, just a startup notice pointing at `/hooks`.

That is correct and desirable behaviour, but it means installing our hooks is not sufficient on its own: the user must also trust them in `/hooks` before a single character appears. Verified both directions on a real machine:

```
without trust:  server request count 7 -> 7   (hooks skipped, no warning at fire time)
with trust:     server request count 7 -> 9   (SessionStart + SessionEnd delivered)
```

Worth surfacing in the Settings UI eventually ("hooks installed, awaiting trust in Codex"), which I've left out of this PR to keep it reviewable. Happy to add it if you'd like it here.

## Notes for review

- No UI changes, so no screenshots of new surfaces — the Codex character renders through the existing webview path with no webview edits, which is the `readingTools` indirection working as designed.
- I did **not** wire a `TeamProvider`: Codex has no Agent Teams equivalent, so `team` stays unset.
- File-fallback (`getSessionDirs`) is deliberately **not** offered. Codex shards rollouts by date (`~/.codex/sessions/<YYYY>/<MM>/<DD>/`) rather than by workspace, so returning those dirs would make the watcher scan every project's sessions. `getAllSessionRoots` is provided for global discovery; hooks are the supported path.
- Happy to split the two shared changes into a separate PR if you'd prefer to review them independently.

